### PR TITLE
TASK-026: Implementar registry, promotion flow e meta-squad do MVP

### DIFF
--- a/decisions/ADR-0007-registry-promotion-approval-flow.md
+++ b/decisions/ADR-0007-registry-promotion-approval-flow.md
@@ -1,0 +1,69 @@
+<!-- TEMPLATE: ADR | version: 1.0 | do not remove this line -->
+
+# ADR-0007: Modelar promotion flow do registry como request + approval explícitos
+
+## Metadados
+
+| Campo | Valor |
+|---|---|
+| **Número** | ADR-0007 |
+| **Status** | accepted |
+| **Data** | 2026-04-24 |
+| **Decisores** | codex |
+| **Issue GitHub** | #10 |
+| **Supersede** |  |
+| **Supersedido por** |  |
+
+---
+
+## Contexto
+
+O MVP já precisa expor lifecycle formal para capabilities, mas a regra operacional do repo exige que nada seja autopublicado. Além disso, o registry precisa suportar promoção, rollback e trilha auditável sem depender de um sistema externo para enforcement.
+
+Sem uma modelagem explícita, a API poderia aceitar `PATCH` de status diretamente e quebrar a separação entre edição de metadata e promoção governada.
+
+---
+
+## Decisão
+
+**O registry vai tratar promoção e rollback como requests explícitos, persistidos em uma coleção própria, e só vai alterar `capability.status` após aprovação humana registrada em `approvals`.**
+
+---
+
+## Justificativa
+
+Essa opção mantém a edição de capability separada da autorização de lifecycle, preserva trilha auditável e evita autopublicação acidental. Também deixa o meta-squad livre para propor mudanças em `draft` sem ganhar permissão implícita de promover.
+
+---
+
+## Alternativas Consideradas
+
+| Opção | Prós | Contras | Razão da Rejeição |
+|---|---|---|---|
+| Request + approval explícitos | Governança clara, audit trail, sem autopublicação | Mais modelagem inicial | N/A — escolhida |
+| PATCH direto de `status` | Simples de implementar | Mistura edição com promoção, frágil para auditoria | Permite autopublicação e enfraquece enforcement |
+| Aprovação fora do registry | Menor acoplamento do registry | Quebra o fluxo local e espalha regras | O MVP precisa do control plane próprio |
+
+---
+
+## Consequências
+
+**Positivas:**
+- promoções e rollbacks ficam auditáveis
+- o meta-squad pode operar em `draft` sem risco de publicar sozinho
+- a API preserva o contrato de governança do MVP
+
+**Negativas / Trade-offs:**
+- exige uma coleção extra para promotions
+- o fluxo de lifecycle fica mais verboso que um `PATCH`
+
+**Riscos:**
+- implementação incompleta de transições pode confundir usuários; mitigar com validação de estado e mensagens explícitas
+
+---
+
+## Referências
+
+- `research/architecture/mvp-server-architecture.md`
+- `research/architecture/user-experience-and-meta-squad.md`
+- `decisions/ADR-0004-capability-registry-and-meta-squad.md`

--- a/handoffs/ACTIVE.md
+++ b/handoffs/ACTIVE.md
@@ -8,39 +8,40 @@
 ## Estado do Bastão
 
 - **baton:** UNASSIGNED
-- **last-updated-by:** codex (TASK-025 concluída / day-1 capabilities)
-- **last-updated-at:** 2026-04-24 10:52 -03
+- **last-updated-by:** codex (TASK-026 concluída / registry-promotion)
+- **last-updated-at:** 2026-04-24 11:15 -03
 - **last-read-by:** codex
-- **last-read-at:** 2026-04-24 10:52 -03
+- **last-read-at:** 2026-04-24 12:02 -03
 
 ---
 
 ## Tasks em Voo
 
 1. Nenhuma task em voo.
-2. O próximo passo é abrir `TASK-026` para registry/promotion flow ou continuar a camada de runtime persistente, sem tocar o modo operacional atual da Doze.
+2. Próximo passo: `TASK-027` para observabilidade, segurança e rollback operacional.
 
 ---
 
 ## Última Ação Completada
 
-Conclusão de `TASK-025` com capacidades day-1 da Doze portadas para o runtime persistente do `product/`.
+Conclusão de `TASK-026` com registry, promotion flow e base do meta-squad do MVP.
 
 **Mudanças concluídas nesta sessão:**
-- issue `#8` aberta para `TASK-025`
-- branch `task/8-day1-capabilities` criada
-- `product/packages/tools/README.md` criado para documentar as bindings day-1
-- `product/packages/tools/src/runner.js` criado com artefatos estruturados para `ga4`, `woocommerce`, `meta-insights`, `hotjar`, `apify`, `canva`, `instagram-publisher` e `blotato`
-- `product/packages/shared/src/seeds.js` atualizado com as capacidades e bindings das squads `marketing-dozecrew` e `inteligencia-dozecrew`
-- `product/packages/runtime/src/service.js` atualizado para executar tool bindings, respeitar allowlist e adiar `blotato` como opcional
-- `product/package.json` atualizado para incluir o novo módulo de tools no check
-- smoke test executado: runs frescos de `marketing-dozecrew` e `inteligencia-dozecrew` produziram artefatos estruturados, checkpoints foram aprovados e `blotato` apareceu como `optional_tool_skipped`
+- issue `#10` aberta para `TASK-026`
+- branch `task/10-registry-promotion` criada a partir de `origin/main`
+- `decisions/ADR-0007-registry-promotion-approval-flow.md` criado para formalizar promotion request + approval explícitos
+- `product/packages/registry/src/service.js` atualizado para CRUD, promotion requests, approvals e rollback
+- `product/apps/api/src/server.js` atualizado com endpoints de capability/promotion e approval
+- `product/packages/shared/contracts/v1/promotion.schema.json` criado e `openclow-api.yaml` ampliado
+- `product/packages/shared/src/seeds.js` atualizado com a capability interna `meta-squad`
+- `product/packages/runtime/src/persistence.js` atualizado com `promotions: []`
+- smoke test executado: capability `content-eval-suite` criada como `draft`, promovida para `staging`, aprovada, revertida para `draft` e trilha persistida com `promotions` e `approvals`
 
 ---
 
 ## Próxima Ação Recomendada
 
-1. Implementar `TASK-026` para registry/promotion flow e estados `draft/staging/active/retired`
+1. Implementar `TASK-027` para observabilidade, segurança e rollback operacional
 2. Manter a raiz estável para não quebrar o modo atual de operação da Doze
 3. Só depois avançar para integrações externas reais e hardening de produção
 
@@ -56,7 +57,7 @@ NENHUM.
 
 ## Snapshot de Contexto
 
-`handoffs/snapshots/2026-04-24-codex-day1-capabilities.md`
+`handoffs/snapshots/2026-04-24-codex-registry-promotion.md`
 
 ---
 
@@ -67,7 +68,7 @@ O repositório agora tem duas camadas ativas e coerentes:
 - a raiz continua sendo a base de trabalho atual da Doze com as empresas da 12
 - `product/` já possui um core server-first executável para desenvolvimento local
 - o benchmark `mkt-ag-dozecrew/opensquad` já influencia seeds, fluxos e checkpoints do workspace `doze`
-- o próximo salto não é mais scaffold, e sim integração com runtime e persistência reais
+- o registry agora tem lifecycle formal e approvals explícitos
 
 **O que fazer a seguir:**
 - portar as capacidades day-1 da Doze para o runtime persistente

--- a/handoffs/snapshots/2026-04-24-codex-registry-promotion.md
+++ b/handoffs/snapshots/2026-04-24-codex-registry-promotion.md
@@ -1,0 +1,49 @@
+<!-- SNAPSHOT: registry promotion -->
+# Snapshot de Contexto - TASK-026
+
+## Estado da task
+
+`TASK-026` implementou o registry/promotion flow do MVP em `product/`.
+
+O fluxo agora suporta:
+- `GET` e `PATCH` de capability por id
+- criação de promotion requests
+- aprovação e rejeição explícitas
+- rollback como promotion request reversa
+- listagem global e por capability de promotions
+
+## Decisões tomadas
+
+- Promotion e rollback são requests explícitos, não `PATCH` direto de status.
+- `capability.status` só muda após aprovação humana registrada em `approvals`.
+- Novas capabilities começam como `draft`.
+- O meta-squad ganha uma capability interna seeded como `draft`.
+
+## Validação executada
+
+- `npm --prefix product run check`
+- create capability draft via `POST /v1/capabilities`
+- promotion request draft -> staging via `POST /v1/capabilities/:id/promotions`
+- approval via `POST /v1/promotions/:id/approve`
+- rollback staging -> draft via `POST /v1/capabilities/:id/promotions`
+- approval de rollback via `POST /v1/promotions/:id/approve`
+
+## Resultado
+
+- A capability testada voltou para `draft` após rollback.
+- A trilha de `promotions` e `approvals` ficou persistida.
+- O comportamento atual da Doze na raiz do repo não foi alterado.
+
+## Próximas ações
+
+1. Preparar `TASK-027` para observabilidade, segurança e rollback operacional.
+2. Consolidar o dashboard e os painéis de promoção, se a próxima task exigir UX.
+3. Manter a operação atual da Doze estável enquanto o `product/` evolui.
+
+## Arquivos relevantes
+
+- [product/packages/registry/src/service.js](/home/acer/Documentos/Projetos/openclow-prep/product/packages/registry/src/service.js)
+- [product/apps/api/src/server.js](/home/acer/Documentos/Projetos/openclow-prep/product/apps/api/src/server.js)
+- [product/packages/shared/contracts/v1/openclow-api.yaml](/home/acer/Documentos/Projetos/openclow-prep/product/packages/shared/contracts/v1/openclow-api.yaml)
+- [product/packages/shared/contracts/v1/promotion.schema.json](/home/acer/Documentos/Projetos/openclow-prep/product/packages/shared/contracts/v1/promotion.schema.json)
+- [decisions/ADR-0007-registry-promotion-approval-flow.md](/home/acer/Documentos/Projetos/openclow-prep/decisions/ADR-0007-registry-promotion-approval-flow.md)

--- a/product/apps/api/README.md
+++ b/product/apps/api/README.md
@@ -4,6 +4,7 @@ Responsável por:
 
 - autenticação e autorização
 - CRUD de capabilities
+- promotion requests e approvals de capability
 - start e consulta de runs
 - checkpoints e approvals
 - outputs e histórico
@@ -20,6 +21,11 @@ Endpoints mínimos já implementados:
 
 - `GET /healthz`
 - `GET|POST /v1/capabilities`
+- `GET|PATCH /v1/capabilities/:id`
+- `GET|POST /v1/capabilities/:id/promotions`
+- `GET /v1/promotions`
+- `POST /v1/promotions/:id/approve`
+- `POST /v1/promotions/:id/reject`
 - `GET /v1/squads`
 - `GET|POST /v1/runs`
 - `GET /v1/runs/:id`

--- a/product/apps/api/src/server.js
+++ b/product/apps/api/src/server.js
@@ -48,10 +48,43 @@ async function handler(request, response) {
       return;
     }
 
+    if (request.method === "GET" && matchRoute(segments, ["v1", "capabilities", "*"])) {
+      const capability = registry.getCapability(segments[2]);
+
+      if (!capability) {
+        notFound(response, "Capability not found");
+        return;
+      }
+
+      sendJson(response, 200, capability);
+      return;
+    }
+
     if (request.method === "POST" && matchRoute(segments, ["v1", "capabilities"])) {
       const payload = await readJson(request);
       const capability = registry.createCapability(payload);
       sendJson(response, 201, capability);
+      return;
+    }
+
+    if (request.method === "PATCH" && matchRoute(segments, ["v1", "capabilities", "*"])) {
+      const payload = await readJson(request);
+      const capability = registry.updateCapability(segments[2], payload);
+      sendJson(response, 200, capability);
+      return;
+    }
+
+    if (request.method === "GET" && matchRoute(segments, ["v1", "capabilities", "*", "promotions"])) {
+      sendJson(response, 200, {
+        items: registry.listPromotions(segments[2])
+      });
+      return;
+    }
+
+    if (request.method === "POST" && matchRoute(segments, ["v1", "capabilities", "*", "promotions"])) {
+      const payload = await readJson(request);
+      const promotion = registry.createPromotion(segments[2], payload);
+      sendJson(response, 202, promotion);
       return;
     }
 
@@ -114,6 +147,29 @@ async function handler(request, response) {
           }))
         )
       });
+      return;
+    }
+
+    if (request.method === "GET" && matchRoute(segments, ["v1", "promotions"])) {
+      const url = new URL(request.url, `http://${host}:${port}`);
+      const capabilityId = url.searchParams.get("capability_id");
+      sendJson(response, 200, {
+        items: registry.listPromotions(capabilityId)
+      });
+      return;
+    }
+
+    if (request.method === "POST" && matchRoute(segments, ["v1", "promotions", "*", "approve"])) {
+      const payload = await readJson(request);
+      const result = registry.approvePromotion(segments[2], payload.actor ?? "human", payload.comment ?? "");
+      sendJson(response, 200, result);
+      return;
+    }
+
+    if (request.method === "POST" && matchRoute(segments, ["v1", "promotions", "*", "reject"])) {
+      const payload = await readJson(request);
+      const result = registry.rejectPromotion(segments[2], payload.actor ?? "human", payload.comment ?? "");
+      sendJson(response, 200, result);
       return;
     }
 

--- a/product/packages/registry/README.md
+++ b/product/packages/registry/README.md
@@ -9,4 +9,4 @@ Responsável por:
 
 ## Primeiro corte executável
 
-`src/service.js` já lista e cria capabilities no runtime local de desenvolvimento.
+`src/service.js` já lista, cria e atualiza capabilities, além de registrar promotion requests e aprovações no runtime local de desenvolvimento.

--- a/product/packages/registry/src/service.js
+++ b/product/packages/registry/src/service.js
@@ -1,5 +1,38 @@
-import { assertCapabilityInput } from "../../shared/src/contracts.js";
+import { assertCapabilityInput, capabilityStatuses } from "../../shared/src/contracts.js";
 import { createId } from "../../shared/src/ids.js";
+
+const capabilityStatusRank = new Map(capabilityStatuses.map((status, index) => [status, index]));
+const allowedTransitions = new Set([
+  "draft->staging",
+  "staging->draft",
+  "staging->active",
+  "active->staging",
+  "active->retired",
+  "retired->active"
+]);
+
+function now() {
+  return new Date().toISOString();
+}
+
+function cloneCapability(capability) {
+  return {
+    ...capability,
+    allowed_tools: [...(capability.allowed_tools ?? [])]
+  };
+}
+
+function ensureValidVersion(version) {
+  if (!/^v?[0-9]+\.[0-9]+\.[0-9]+$/.test(version)) {
+    throw new Error("Capability version must be semver-like");
+  }
+}
+
+function ensureAllowedTransition(fromStatus, toStatus) {
+  if (!allowedTransitions.has(`${fromStatus}->${toStatus}`)) {
+    throw new Error(`Invalid capability transition: ${fromStatus} -> ${toStatus}`);
+  }
+}
 
 export class RegistryService {
   constructor(store) {
@@ -10,23 +43,226 @@ export class RegistryService {
     return this.store.capabilities;
   }
 
+  getCapability(capabilityId) {
+    return this.store.capabilities.find(
+      (candidate) => candidate.id === capabilityId || candidate.slug === capabilityId
+    );
+  }
+
+  listPromotions(capabilityId = null) {
+    const promotions = this.store.promotions ?? [];
+
+    if (!capabilityId) {
+      return promotions;
+    }
+
+    return promotions.filter(
+      (promotion) => promotion.capability_id === capabilityId || promotion.capability_slug === capabilityId
+    );
+  }
+
   createCapability(input) {
-    assertCapabilityInput(input);
+    assertCapabilityInput({
+      ...input,
+      status: input.status ?? "draft"
+    });
+
+    if (input.status && input.status !== "draft") {
+      throw new Error("New capabilities must be created as draft and promoted explicitly");
+    }
+
+    ensureValidVersion(input.version ?? "1.0.0");
 
     const capability = {
       id: createId(),
+      kind: input.kind,
+      slug: input.slug,
       name: input.name ?? input.slug,
+      workspace_slug: input.workspace_slug,
+      status: "draft",
       version: input.version ?? "1.0.0",
       risk_level: input.risk_level ?? "medium",
-      allowed_tools: input.allowed_tools ?? [],
+      allowed_tools: [...(input.allowed_tools ?? [])],
       summary: input.summary ?? "",
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-      ...input
+      created_at: now(),
+      updated_at: now()
     };
 
     this.store.capabilities.push(capability);
     this.store.persist?.();
     return capability;
+  }
+
+  updateCapability(capabilityId, input) {
+    const capability = this.getCapability(capabilityId);
+
+    if (!capability) {
+      throw new Error("Capability not found");
+    }
+
+    if (input.slug && input.slug !== capability.slug) {
+      throw new Error("Capability slug cannot be changed");
+    }
+
+    if (input.workspace_slug && input.workspace_slug !== capability.workspace_slug) {
+      throw new Error("Capability workspace_slug cannot be changed");
+    }
+
+    if (input.kind && input.kind !== capability.kind) {
+      throw new Error("Capability kind cannot be changed");
+    }
+
+    if (input.status && input.status !== capability.status) {
+      throw new Error("Capability status can only be changed through promotion");
+    }
+
+    if (input.version) {
+      ensureValidVersion(input.version);
+      capability.version = input.version;
+    }
+
+    if (input.name) {
+      capability.name = input.name;
+    }
+
+    if (input.risk_level) {
+      capability.risk_level = input.risk_level;
+    }
+
+    if (input.summary !== undefined) {
+      capability.summary = input.summary;
+    }
+
+    if (input.allowed_tools) {
+      capability.allowed_tools = [...input.allowed_tools];
+    }
+
+    capability.updated_at = now();
+    this.store.persist?.();
+    return capability;
+  }
+
+  createPromotion(capabilityId, input) {
+    const capability = this.getCapability(capabilityId);
+
+    if (!capability) {
+      throw new Error("Capability not found");
+    }
+
+    const targetStatus = input.target_status;
+
+    if (!capabilityStatuses.includes(targetStatus)) {
+      throw new Error(`Promotion target must be one of: ${capabilityStatuses.join(", ")}`);
+    }
+
+    if (targetStatus === capability.status) {
+      throw new Error("Promotion target must differ from current capability status");
+    }
+
+    ensureAllowedTransition(capability.status, targetStatus);
+
+    const promotion = {
+      id: createId(),
+      capability_id: capability.id,
+      capability_slug: capability.slug,
+      from_status: capability.status,
+      to_status: targetStatus,
+      operation:
+        capabilityStatusRank.get(targetStatus) > capabilityStatusRank.get(capability.status)
+          ? "promotion"
+          : "rollback",
+      status: "pending",
+      requested_by: input.requested_by ?? "human",
+      reason: input.reason ?? "",
+      comment: input.comment ?? "",
+      requested_at: now(),
+      updated_at: now(),
+      approval_id: null,
+      approved_at: null,
+      rejected_at: null
+    };
+
+    this.store.promotions.push(promotion);
+    this.store.persist?.();
+    return promotion;
+  }
+
+  approvePromotion(promotionId, actor, comment = "") {
+    const promotion = this.store.promotions.find((candidate) => candidate.id === promotionId);
+
+    if (!promotion) {
+      throw new Error("Promotion not found");
+    }
+
+    if (promotion.status !== "pending") {
+      throw new Error("Promotion already decided");
+    }
+
+    const capability = this.getCapability(promotion.capability_id);
+
+    if (!capability) {
+      throw new Error("Capability not found");
+    }
+
+    capability.status = promotion.to_status;
+    capability.updated_at = now();
+
+    const approval = {
+      id: createId(),
+      target_kind: "promotion",
+      target_id: promotion.id,
+      decision: "approved",
+      actor,
+      comment,
+      created_at: now()
+    };
+
+    promotion.status = "approved";
+    promotion.approval_id = approval.id;
+    promotion.approved_at = approval.created_at;
+    promotion.updated_at = approval.created_at;
+
+    this.store.approvals.push(approval);
+    this.store.persist?.();
+
+    return {
+      promotion,
+      approval,
+      capability: cloneCapability(capability)
+    };
+  }
+
+  rejectPromotion(promotionId, actor, comment = "") {
+    const promotion = this.store.promotions.find((candidate) => candidate.id === promotionId);
+
+    if (!promotion) {
+      throw new Error("Promotion not found");
+    }
+
+    if (promotion.status !== "pending") {
+      throw new Error("Promotion already decided");
+    }
+
+    const approval = {
+      id: createId(),
+      target_kind: "promotion",
+      target_id: promotion.id,
+      decision: "rejected",
+      actor,
+      comment,
+      created_at: now()
+    };
+
+    promotion.status = "rejected";
+    promotion.rejected_at = approval.created_at;
+    promotion.updated_at = approval.created_at;
+
+    this.store.approvals.push(approval);
+    this.store.persist?.();
+
+    return {
+      promotion,
+      approval
+    };
   }
 }

--- a/product/packages/runtime/src/persistence.js
+++ b/product/packages/runtime/src/persistence.js
@@ -19,6 +19,7 @@ export function createInitialState() {
     runs: [],
     checkpoints: [],
     approvals: [],
+    promotions: [],
     queue: [],
     runtime: {
       ollama: {

--- a/product/packages/shared/contracts/v1/openclow-api.yaml
+++ b/product/packages/shared/contracts/v1/openclow-api.yaml
@@ -34,13 +34,42 @@ paths:
         "200":
           description: Capability updated
   /capabilities/{capabilityId}/promotions:
+    get:
+      summary: List promotions for a capability
+      parameters:
+        - $ref: "#/components/parameters/CapabilityId"
+      responses:
+        "200":
+          description: Promotion collection
     post:
-      summary: Promote capability between lifecycle stages
+      summary: Request promotion or rollback for a capability
       parameters:
         - $ref: "#/components/parameters/CapabilityId"
       responses:
         "202":
           description: Promotion queued for approval
+  /promotions:
+    get:
+      summary: List promotions
+      responses:
+        "200":
+          description: Promotion collection
+  /promotions/{promotionId}/approve:
+    post:
+      summary: Approve promotion
+      parameters:
+        - $ref: "#/components/parameters/PromotionId"
+      responses:
+        "200":
+          description: Promotion approved
+  /promotions/{promotionId}/reject:
+    post:
+      summary: Reject promotion
+      parameters:
+        - $ref: "#/components/parameters/PromotionId"
+      responses:
+        "200":
+          description: Promotion rejected
   /runs:
     post:
       summary: Start run
@@ -83,6 +112,13 @@ components:
   parameters:
     CapabilityId:
       name: capabilityId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    PromotionId:
+      name: promotionId
       in: path
       required: true
       schema:

--- a/product/packages/shared/contracts/v1/promotion.schema.json
+++ b/product/packages/shared/contracts/v1/promotion.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openclow.local/contracts/v1/promotion.schema.json",
+  "title": "Promotion",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "capability_id",
+    "capability_slug",
+    "from_status",
+    "to_status",
+    "operation",
+    "status",
+    "requested_by",
+    "requested_at",
+    "updated_at"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "capability_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "capability_slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$"
+    },
+    "from_status": {
+      "type": "string",
+      "enum": ["draft", "staging", "active", "retired"]
+    },
+    "to_status": {
+      "type": "string",
+      "enum": ["draft", "staging", "active", "retired"]
+    },
+    "operation": {
+      "type": "string",
+      "enum": ["promotion", "rollback"]
+    },
+    "status": {
+      "type": "string",
+      "enum": ["pending", "approved", "rejected"]
+    },
+    "requested_by": {
+      "type": "string",
+      "minLength": 1
+    },
+    "reason": {
+      "type": "string"
+    },
+    "comment": {
+      "type": "string"
+    },
+    "requested_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "approval_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "approved_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "rejected_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/product/packages/shared/src/seeds.js
+++ b/product/packages/shared/src/seeds.js
@@ -183,6 +183,18 @@ export function createSeeds() {
       risk_level: "critical",
       allowed_tools: ["instagram-publisher"],
       summary: "Publicação direta sujeita a checkpoint"
+    },
+    {
+      id: createId(),
+      kind: "squad",
+      slug: "meta-squad",
+      name: "Meta Squad",
+      workspace_slug: "openclow",
+      status: "draft",
+      version: "1.0.0",
+      risk_level: "high",
+      allowed_tools: [],
+      summary: "Capability interna para criar, revisar e promover outras capabilities"
     }
   ];
 

--- a/workboard/DONE.md
+++ b/workboard/DONE.md
@@ -21,6 +21,24 @@
 
 ## Histórico
 
+### TASK-026 | Implementar registry, promotion flow e meta-squad do MVP
+- **Concluída em:** 2026-04-24
+- **Por:** codex
+- **Issue:** #10 (fechada)
+- **Branch:** task/10-registry-promotion
+- **Output produzido:**
+  - `decisions/ADR-0007-registry-promotion-approval-flow.md`
+  - `product/packages/registry/src/service.js`
+  - `product/apps/api/src/server.js`
+  - `product/packages/shared/contracts/v1/promotion.schema.json`
+  - `product/packages/shared/contracts/v1/openclow-api.yaml`
+  - `product/packages/runtime/src/persistence.js`
+  - `product/packages/shared/src/seeds.js`
+  - `product/apps/api/README.md`
+  - `product/packages/registry/README.md`
+  - atualização de `workboard/IN_PROGRESS.md` e `handoffs/ACTIVE.md`
+- **Notas:** O registry agora registra capabilities, promotion requests e rollback explícitos com aprovação humana. O meta-squad ganhou uma capability interna seeded como `draft`. Smoke test validou promotion `draft -> staging`, approval, rollback `staging -> draft` e trilha persistida em `approvals`/`promotions`.
+
 ### TASK-025 | Portar capacidades day-1 da Doze para o OpenClow
 - **Concluída em:** 2026-04-24
 - **Por:** codex


### PR DESCRIPTION
Closes #10

Resumo:
- implementa registry com lifecycle formal de capabilities
- adiciona promotion requests explícitas e approvals humanas
- inclui rollback como fluxo explícito
- adiciona capability interna de meta-squad como base seed

Validação:
- `npm --prefix product run check`
- smoke do API com capability draft criada
- promoção draft -> staging aprovada
- rollback staging -> draft aprovado
- trilha persistida em `promotions` e `approvals`

Artefatos principais:
- `product/packages/registry/src/service.js`
- `product/apps/api/src/server.js`
- `product/packages/shared/contracts/v1/promotion.schema.json`
- `decisions/ADR-0007-registry-promotion-approval-flow.md`
- `handoffs/snapshots/2026-04-24-codex-registry-promotion.md`