### PR TITLE
TASK-038: define contracts e manifests do sistema criativo

### DIFF
--- a/handoffs/ACTIVE.md
+++ b/handoffs/ACTIVE.md
@@ -8,7 +8,7 @@
 ## Estado do Bastão
 
 - **baton:** UNASSIGNED
-- **last-updated-by:** codex (task 037 completed)
+- **last-updated-by:** codex (task 038 completed)
 - **last-updated-at:** 2026-04-24
 - **last-read-by:** codex
 - **last-read-at:** 2026-04-24
@@ -17,30 +17,34 @@
 
 ## Tasks em Voo
 
-1. TASK-037 concluída com a arquitetura de referência dos workflows criativos.
-2. Próximo passo: iniciar `TASK-038` no backlog.
+1. TASK-038 concluída com contracts e seeds implementáveis para a trilha criativa.
+2. Próximo passo: iniciar `TASK-039` no backlog.
 
 ---
 
 ## Última Ação Completada
 
-Fechamento da arquitetura de referência para workflows criativos com `OpenClow + Paperclip`.
+Fechamento da TASK-038 com contracts públicos e seeds iniciais do sistema criativo.
 
 **Mudanças concluídas nesta sessão:**
-- `research/architecture/creative-workflow-reference-architecture.md` criado
-- `research/ecosystem-fit/creative-tooling-profiles.md` criado
-- `research/architecture/README.md` e `research/ecosystem-fit/README.md` atualizados
-- `workboard/BACKLOG.md` atualizado com `TASK-038`
+- `research/architecture/creative-agent-contracts.md` criado
+- `research/architecture/creative-squad-manifests.md` criado
+- schemas de `product/packages/shared/contracts/v1/` expandidos para a trilha criativa
+- `product/packages/shared/src/seeds.js` atualizado com squads e capabilities criativas iniciais
+- `product/packages/skills/src/catalog.js` atualizado com skills criativas iniciais
+- `product/packages/shared/contracts/v1/openclow-api.yaml` alinhado com a superfície atual
+- `npm --prefix product run check` executado com sucesso
+- `workboard/BACKLOG.md` atualizado com `TASK-039`
 - `workboard/IN_PROGRESS.md` zerado
-- `workboard/DONE.md` atualizado para incluir `TASK-037`
-- `handoffs/ACTIVE.md` reconciliado para refletir o fechamento da TASK-037
+- `workboard/DONE.md` atualizado para incluir `TASK-038`
+- `handoffs/ACTIVE.md` reconciliado para refletir o fechamento da TASK-038
 
 ---
 
 ## Próxima Ação Recomendada
 
-1. Iniciar `TASK-038`
-2. Converter a arquitetura em contracts e manifests implementáveis
+1. Iniciar `TASK-039`
+2. Implementar o primeiro corte criativo em `product/`
 3. Manter staging-first antes de qualquer passo ligado ao servidor de produção
 
 **Papéis recomendados para a próxima sessão:** `Program Architect`, `Workflow Field Researcher`
@@ -55,7 +59,7 @@ NENHUM.
 
 ## Snapshot de Contexto
 
-`handoffs/snapshots/2026-04-24-codex-task-037-complete.md`
+`handoffs/snapshots/2026-04-24-codex-task-038-complete.md`
 
 ---
 
@@ -69,8 +73,8 @@ O repositório agora tem duas camadas ativas e coerentes:
 - o registry agora tem lifecycle formal e approvals explícitos
 
 **O que fazer a seguir:**
-- iniciar `TASK-038`
-- transformar a arquitetura em contracts, manifests e recorte implementável em `product/`
+- iniciar `TASK-039`
+- implementar o primeiro corte criativo seeded em `product/`
 - seguir preservando o fluxo operacional atual da Doze e o guardrail de staging-first
 
 **Próximo agente recomendado:** `Program Architect` com apoio de `Workflow Field Researcher`

--- a/handoffs/snapshots/2026-04-24-codex-task-038-complete.md
+++ b/handoffs/snapshots/2026-04-24-codex-task-038-complete.md
@@ -1,0 +1,26 @@
+# Snapshot — TASK-038
+
+**Data:** 2026-04-24  
+**Agente:** codex  
+**Branch:** `task/20-creative-contracts-manifests`  
+**Issue:** `#20`
+
+## Objetivo
+
+Converter a arquitetura criativa em contracts públicos, manifests e seeds implementáveis para o `product/`.
+
+## Entregas
+
+- contracts criativos em `research/architecture/creative-agent-contracts.md`
+- manifests em `research/architecture/creative-squad-manifests.md`
+- schemas compartilhados expandidos em `product/packages/shared/contracts/v1/`
+- seeds criativos iniciais em `product/packages/shared/src/seeds.js`
+- catálogo de skills criativas em `product/packages/skills/src/catalog.js`
+
+## Validação
+
+- `npm --prefix product run check` passou
+
+## Próxima ação recomendada
+
+Iniciar `TASK-039` para implementar no `product/` o primeiro corte criativo seeded: `creative-control`, `reference-lab` e `creative-qa`.

--- a/product/packages/shared/contracts/v1/approval.schema.json
+++ b/product/packages/shared/contracts/v1/approval.schema.json
@@ -25,6 +25,14 @@
       "type": "string",
       "format": "uuid"
     },
+    "workspace_slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$"
+    },
+    "environment_scope": {
+      "type": "string",
+      "enum": ["local-dev", "staging", "production"]
+    },
     "decision": {
       "type": "string",
       "enum": ["approved", "rejected"]

--- a/product/packages/shared/contracts/v1/capability.schema.json
+++ b/product/packages/shared/contracts/v1/capability.schema.json
@@ -56,6 +56,31 @@
     "summary": {
       "type": "string"
     },
+    "system_family": {
+      "type": "string",
+      "enum": ["core", "analytics", "creative", "publishing", "governance"]
+    },
+    "machine_profile": {
+      "type": "string",
+      "enum": ["cpu-safe", "balanced", "quality-first"]
+    },
+    "environment_scope": {
+      "type": "string",
+      "enum": ["local-dev", "staging", "production"]
+    },
+    "supports_dry_run": {
+      "type": "boolean"
+    },
+    "requires_checkpoint": {
+      "type": "boolean"
+    },
+    "artifact_contracts": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
     "created_at": {
       "type": "string",
       "format": "date-time"

--- a/product/packages/shared/contracts/v1/checkpoint.schema.json
+++ b/product/packages/shared/contracts/v1/checkpoint.schema.json
@@ -37,6 +37,10 @@
       "type": "string",
       "minLength": 1
     },
+    "gate_kind": {
+      "type": "string",
+      "enum": ["strategy", "content", "design", "brand-qa", "delivery-qa", "publication"]
+    },
     "on_reject": {
       "type": "string"
     },

--- a/product/packages/shared/contracts/v1/openclow-api.yaml
+++ b/product/packages/shared/contracts/v1/openclow-api.yaml
@@ -6,6 +6,8 @@ info:
     API minima do MVP para capabilities, runs, checkpoints, approvals e outputs.
     Mutating requests carry actor/requested_by/workspace_slug in the current MVP
     until dedicated session and identity headers are introduced.
+    Creative workflows may also declare machine_profile, environment_scope
+    and artifact contracts inside the public schemas.
 servers:
   - url: https://openclow.local/v1
 paths:
@@ -26,6 +28,12 @@ paths:
       responses:
         "201":
           description: Capability created
+  /squads:
+    get:
+      summary: List squads
+      responses:
+        "200":
+          description: Squad collection
   /capabilities/{capabilityId}:
     get:
       summary: Get capability
@@ -117,6 +125,12 @@ paths:
       responses:
         "200":
           description: Output collection
+  /checkpoints:
+    get:
+      summary: List checkpoints
+      responses:
+        "200":
+          description: Checkpoint collection
   /checkpoints/{checkpointId}/approve:
     post:
       summary: Approve checkpoint

--- a/product/packages/shared/contracts/v1/pipeline.schema.json
+++ b/product/packages/shared/contracts/v1/pipeline.schema.json
@@ -15,9 +15,25 @@
       "type": "string",
       "format": "uuid"
     },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "workspace_slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$"
+    },
     "version": {
       "type": "string",
       "pattern": "^v?[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "machine_profile": {
+      "type": "string",
+      "enum": ["cpu-safe", "balanced", "quality-first"]
+    },
+    "environment_scope": {
+      "type": "string",
+      "enum": ["local-dev", "staging", "production"]
     },
     "entry_step": {
       "type": "string",

--- a/product/packages/shared/contracts/v1/run.schema.json
+++ b/product/packages/shared/contracts/v1/run.schema.json
@@ -28,6 +28,25 @@
       "type": "string",
       "pattern": "^[a-z0-9-]+$"
     },
+    "intent_kind": {
+      "type": "string",
+      "enum": ["analysis", "creative-image", "creative-video", "publishing", "governance"]
+    },
+    "machine_profile": {
+      "type": "string",
+      "enum": ["cpu-safe", "balanced", "quality-first"]
+    },
+    "environment_scope": {
+      "type": "string",
+      "enum": ["local-dev", "staging", "production"]
+    },
+    "requested_capability_ids": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uuid"
+      }
+    },
     "status": {
       "type": "string",
       "enum": [

--- a/product/packages/shared/contracts/v1/squad.schema.json
+++ b/product/packages/shared/contracts/v1/squad.schema.json
@@ -52,6 +52,32 @@
     "default_model_tier": {
       "type": "string",
       "enum": ["fast", "powerful"]
+    },
+    "system_family": {
+      "type": "string",
+      "enum": ["core", "analytics", "creative", "publishing", "governance"]
+    },
+    "machine_profile": {
+      "type": "string",
+      "enum": ["cpu-safe", "balanced", "quality-first"]
+    },
+    "environment_scope": {
+      "type": "string",
+      "enum": ["local-dev", "staging", "production"]
+    },
+    "context_precedence": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["operational-truth", "campaign-context", "brand-profile", "creative-playbook"]
+      }
+    },
+    "qa_capability_ids": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uuid"
+      }
     }
   }
 }

--- a/product/packages/shared/contracts/v1/step.schema.json
+++ b/product/packages/shared/contracts/v1/step.schema.json
@@ -22,9 +22,57 @@
       "type": "string",
       "enum": ["inline", "subagent", "tool-runner", "checkpoint"]
     },
+    "label": {
+      "type": "string",
+      "minLength": 1
+    },
     "uses_capability_id": {
       "type": "string",
       "format": "uuid"
+    },
+    "tool_slugs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "optional_tool_slugs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "input_contracts": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "output_contracts": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "machine_profile": {
+      "type": "string",
+      "enum": ["cpu-safe", "balanced", "quality-first"]
+    },
+    "environment_scope": {
+      "type": "string",
+      "enum": ["local-dev", "staging", "production"]
+    },
+    "qa_gate": {
+      "type": "string",
+      "enum": ["none", "brand", "delivery", "brand-and-delivery"]
+    },
+    "risk_level": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "critical"]
     },
     "on_success": {
       "type": "string"

--- a/product/packages/shared/src/contracts.js
+++ b/product/packages/shared/src/contracts.js
@@ -1,5 +1,7 @@
 export const capabilityKinds = ["skill", "squad", "pipeline", "tool"];
 export const capabilityStatuses = ["draft", "staging", "active", "retired"];
+export const machineProfiles = ["cpu-safe", "balanced", "quality-first"];
+export const environmentScopes = ["local-dev", "staging", "production"];
 export const runStatuses = [
   "queued",
   "running",
@@ -25,6 +27,14 @@ export function assertCapabilityInput(input) {
 
   if (!input.workspace_slug) {
     throw new Error("Capability workspace_slug is required");
+  }
+
+  if (input.machine_profile && !machineProfiles.includes(input.machine_profile)) {
+    throw new Error(`Capability machine_profile must be one of: ${machineProfiles.join(", ")}`);
+  }
+
+  if (input.environment_scope && !environmentScopes.includes(input.environment_scope)) {
+    throw new Error(`Capability environment_scope must be one of: ${environmentScopes.join(", ")}`);
   }
 }
 

--- a/product/packages/shared/src/seeds.js
+++ b/product/packages/shared/src/seeds.js
@@ -98,6 +98,122 @@ function createIntelligenceSteps() {
   ];
 }
 
+function createCreativeControlSteps() {
+  return [
+    {
+      id: "resolver-contexto",
+      kind: "subagent",
+      executor: "subagent",
+      label: "Resolve contexto de marca, campanha e verdade operacional",
+      tool_slugs: ["brand-context-orchestrator"],
+      output_contracts: ["brand_context.json"],
+      machine_profile: "cpu-safe",
+      environment_scope: "local-dev",
+      qa_gate: "none",
+      risk_level: "low"
+    },
+    {
+      id: "construir-intencao",
+      kind: "prompt",
+      executor: "inline",
+      label: "Consolida intenção criativa e packet de aprovação",
+      input_contracts: ["brand_context.json", "reference_pack.json"],
+      output_contracts: ["creative_intent.json", "approval_packet.json"],
+      machine_profile: "balanced",
+      environment_scope: "local-dev",
+      qa_gate: "brand",
+      risk_level: "medium"
+    },
+    {
+      id: "aprovar-intencao",
+      kind: "checkpoint",
+      executor: "checkpoint",
+      label: "Aprovar intenção criativa antes da composição",
+      input_contracts: ["approval_packet.json"],
+      requiresCheckpoint: true,
+      on_reject: "resolver-contexto",
+      machine_profile: "cpu-safe",
+      environment_scope: "staging",
+      qa_gate: "brand",
+      risk_level: "medium"
+    }
+  ];
+}
+
+function createReferenceLabSteps() {
+  return [
+    {
+      id: "ingestao-referencias",
+      kind: "tool",
+      executor: "subagent",
+      label: "Ingesta referências explícitas e assets anexados",
+      tool_slugs: ["reference-fetcher"],
+      output_contracts: ["reference_pack.json"],
+      machine_profile: "cpu-safe",
+      environment_scope: "local-dev",
+      qa_gate: "none",
+      risk_level: "low"
+    },
+    {
+      id: "enriquecimento-estilo",
+      kind: "subagent",
+      executor: "subagent",
+      label: "Enriquece referências em sinais visuais e anti-patterns",
+      tool_slugs: ["reference-enricher"],
+      input_contracts: ["reference_pack.json"],
+      output_contracts: ["style_signals.json", "visual_anti_patterns.json", "reference_pack.json"],
+      machine_profile: "balanced",
+      environment_scope: "local-dev",
+      qa_gate: "brand",
+      risk_level: "low"
+    }
+  ];
+}
+
+function createCreativeQaSteps() {
+  return [
+    {
+      id: "qa-identidade",
+      kind: "prompt",
+      executor: "inline",
+      label: "Executa QA de identidade da peça",
+      tool_slugs: ["brand-qa"],
+      input_contracts: ["creative_intent.json"],
+      output_contracts: ["qa_report_brand.json"],
+      machine_profile: "cpu-safe",
+      environment_scope: "staging",
+      qa_gate: "brand",
+      risk_level: "medium"
+    },
+    {
+      id: "qa-entrega",
+      kind: "prompt",
+      executor: "inline",
+      label: "Executa QA técnico e readiness de entrega",
+      tool_slugs: ["delivery-qa"],
+      input_contracts: ["creative_intent.json"],
+      output_contracts: ["qa_report_delivery.json"],
+      machine_profile: "cpu-safe",
+      environment_scope: "staging",
+      qa_gate: "delivery",
+      risk_level: "medium"
+    },
+    {
+      id: "aprovar-qa",
+      kind: "checkpoint",
+      executor: "checkpoint",
+      label: "Aprovar QA antes da publicação ou render final",
+      input_contracts: ["qa_report_brand.json", "qa_report_delivery.json"],
+      requiresCheckpoint: true,
+      on_reject: "qa-identidade",
+      machine_profile: "cpu-safe",
+      environment_scope: "staging",
+      qa_gate: "brand-and-delivery",
+      risk_level: "high"
+    }
+  ];
+}
+
 export function createSeeds() {
   const capabilities = [
     {
@@ -195,11 +311,176 @@ export function createSeeds() {
       risk_level: "high",
       allowed_tools: [],
       summary: "Capability interna para criar, revisar e promover outras capabilities"
+    },
+    {
+      id: createId(),
+      kind: "skill",
+      slug: "brand-context-orchestrator",
+      name: "Brand Context Orchestrator",
+      workspace_slug: "doze",
+      status: "draft",
+      version: "1.0.0",
+      risk_level: "medium",
+      allowed_tools: ["brand-context-orchestrator"],
+      summary: "Resolve brand profile, campaign context e verdade operacional",
+      system_family: "creative",
+      machine_profile: "cpu-safe",
+      environment_scope: "local-dev",
+      supports_dry_run: true,
+      requires_checkpoint: false,
+      artifact_contracts: ["brand_context.json"]
+    },
+    {
+      id: createId(),
+      kind: "tool",
+      slug: "reference-fetcher",
+      name: "Reference Fetcher",
+      workspace_slug: "doze",
+      status: "draft",
+      version: "1.0.0",
+      risk_level: "low",
+      allowed_tools: ["reference-fetcher"],
+      summary: "Ingesta links e assets de referência",
+      system_family: "creative",
+      machine_profile: "cpu-safe",
+      environment_scope: "local-dev",
+      supports_dry_run: true,
+      requires_checkpoint: false,
+      artifact_contracts: ["reference_pack.json"]
+    },
+    {
+      id: createId(),
+      kind: "skill",
+      slug: "reference-enricher",
+      name: "Reference Enricher",
+      workspace_slug: "doze",
+      status: "draft",
+      version: "1.0.0",
+      risk_level: "low",
+      allowed_tools: ["reference-enricher"],
+      summary: "Traduz referências em sinais visuais e anti-patterns",
+      system_family: "creative",
+      machine_profile: "balanced",
+      environment_scope: "local-dev",
+      supports_dry_run: true,
+      requires_checkpoint: false,
+      artifact_contracts: ["reference_pack.json", "style_signals.json", "visual_anti_patterns.json"]
+    },
+    {
+      id: createId(),
+      kind: "skill",
+      slug: "creative-director",
+      name: "Creative Director",
+      workspace_slug: "doze",
+      status: "draft",
+      version: "1.0.0",
+      risk_level: "medium",
+      allowed_tools: ["creative-director"],
+      summary: "Consolida intenção criativa e treatment executável",
+      system_family: "creative",
+      machine_profile: "balanced",
+      environment_scope: "local-dev",
+      supports_dry_run: true,
+      requires_checkpoint: true,
+      artifact_contracts: ["creative_intent.json", "approval_packet.json"]
+    },
+    {
+      id: createId(),
+      kind: "skill",
+      slug: "brand-qa",
+      name: "Brand QA",
+      workspace_slug: "doze",
+      status: "draft",
+      version: "1.0.0",
+      risk_level: "medium",
+      allowed_tools: ["brand-qa"],
+      summary: "Valida aderência da peça à identidade da empresa",
+      system_family: "creative",
+      machine_profile: "cpu-safe",
+      environment_scope: "staging",
+      supports_dry_run: true,
+      requires_checkpoint: true,
+      artifact_contracts: ["qa_report_brand.json"]
+    },
+    {
+      id: createId(),
+      kind: "skill",
+      slug: "delivery-qa",
+      name: "Delivery QA",
+      workspace_slug: "doze",
+      status: "draft",
+      version: "1.0.0",
+      risk_level: "medium",
+      allowed_tools: ["delivery-qa"],
+      summary: "Valida export, pacing e readiness de entrega",
+      system_family: "creative",
+      machine_profile: "cpu-safe",
+      environment_scope: "staging",
+      supports_dry_run: true,
+      requires_checkpoint: true,
+      artifact_contracts: ["qa_report_delivery.json"]
+    },
+    {
+      id: createId(),
+      kind: "tool",
+      slug: "paperclip-composer",
+      name: "Paperclip Composer",
+      workspace_slug: "doze",
+      status: "draft",
+      version: "1.0.0",
+      risk_level: "medium",
+      allowed_tools: ["paperclip-composer"],
+      summary: "Composição declarativa de layouts, timelines e overlays",
+      system_family: "creative",
+      machine_profile: "balanced",
+      environment_scope: "staging",
+      supports_dry_run: true,
+      requires_checkpoint: false,
+      artifact_contracts: ["asset_plan.json", "shot_plan.json"]
+    },
+    {
+      id: createId(),
+      kind: "tool",
+      slug: "ffmpeg-render",
+      name: "FFmpeg Render",
+      workspace_slug: "doze",
+      status: "draft",
+      version: "1.0.0",
+      risk_level: "medium",
+      allowed_tools: ["ffmpeg-render"],
+      summary: "Render, transformações de mídia e extração de previews",
+      system_family: "creative",
+      machine_profile: "balanced",
+      environment_scope: "staging",
+      supports_dry_run: true,
+      requires_checkpoint: false,
+      artifact_contracts: ["edit_decision_list.json", "preview_manifest.json", "vfx_plan.json"]
+    },
+    {
+      id: createId(),
+      kind: "tool",
+      slug: "publish-dry-run",
+      name: "Publish Dry Run",
+      workspace_slug: "doze",
+      status: "draft",
+      version: "1.0.0",
+      risk_level: "high",
+      allowed_tools: ["publish-dry-run"],
+      summary: "Empacota publicação em modo dry-run e gera receipts",
+      system_family: "publishing",
+      machine_profile: "cpu-safe",
+      environment_scope: "staging",
+      supports_dry_run: true,
+      requires_checkpoint: true,
+      artifact_contracts: ["publication_plan.json", "publish_receipt.json"]
     }
   ];
 
   const marketingId = createId();
   const intelligenceId = createId();
+  const creativeControlId = createId();
+  const referenceLabId = createId();
+  const creativeQaId = createId();
 
   const squads = [
     {
@@ -227,6 +508,69 @@ export function createSeeds() {
       memory_scope: "squad",
       default_model_tier: "powerful",
       steps: createIntelligenceSteps()
+    },
+    {
+      id: creativeControlId,
+      slug: "creative-control",
+      name: "Creative Control",
+      workspace_slug: "doze",
+      version: "1.0.0",
+      pipeline_id: createId(),
+      capability_ids: capabilities
+        .filter((capability) =>
+          ["brand-context-orchestrator", "creative-director", "brand-qa", "delivery-qa"].includes(capability.slug)
+        )
+        .map((capability) => capability.id),
+      memory_scope: "run",
+      default_model_tier: "powerful",
+      system_family: "creative",
+      machine_profile: "balanced",
+      environment_scope: "staging",
+      context_precedence: ["operational-truth", "campaign-context", "brand-profile", "creative-playbook"],
+      qa_capability_ids: capabilities
+        .filter((capability) => ["brand-qa", "delivery-qa"].includes(capability.slug))
+        .map((capability) => capability.id),
+      steps: createCreativeControlSteps()
+    },
+    {
+      id: referenceLabId,
+      slug: "reference-lab",
+      name: "Reference Lab",
+      workspace_slug: "doze",
+      version: "1.0.0",
+      pipeline_id: createId(),
+      capability_ids: capabilities
+        .filter((capability) => ["reference-fetcher", "reference-enricher"].includes(capability.slug))
+        .map((capability) => capability.id),
+      memory_scope: "run",
+      default_model_tier: "powerful",
+      system_family: "creative",
+      machine_profile: "balanced",
+      environment_scope: "local-dev",
+      context_precedence: ["operational-truth", "campaign-context", "brand-profile", "creative-playbook"],
+      qa_capability_ids: [],
+      steps: createReferenceLabSteps()
+    },
+    {
+      id: creativeQaId,
+      slug: "creative-qa",
+      name: "Creative QA",
+      workspace_slug: "doze",
+      version: "1.0.0",
+      pipeline_id: createId(),
+      capability_ids: capabilities
+        .filter((capability) => ["brand-qa", "delivery-qa"].includes(capability.slug))
+        .map((capability) => capability.id),
+      memory_scope: "run",
+      default_model_tier: "fast",
+      system_family: "creative",
+      machine_profile: "cpu-safe",
+      environment_scope: "staging",
+      context_precedence: ["operational-truth", "campaign-context", "brand-profile", "creative-playbook"],
+      qa_capability_ids: capabilities
+        .filter((capability) => ["brand-qa", "delivery-qa"].includes(capability.slug))
+        .map((capability) => capability.id),
+      steps: createCreativeQaSteps()
     }
   ];
 

--- a/product/packages/skills/src/catalog.js
+++ b/product/packages/skills/src/catalog.js
@@ -1,5 +1,50 @@
 export const skillCatalog = [
   {
+    slug: "brand-context-orchestrator",
+    mode: "inline",
+    description: "Resolve contexto de marca, campanha e verdade operacional"
+  },
+  {
+    slug: "reference-fetcher",
+    mode: "mcp",
+    description: "Ingesta links e assets de referência"
+  },
+  {
+    slug: "reference-enricher",
+    mode: "inline",
+    description: "Traduz referências em sinais visuais e anti-patterns"
+  },
+  {
+    slug: "creative-director",
+    mode: "inline",
+    description: "Gera a intenção criativa e o treatment da peça"
+  },
+  {
+    slug: "brand-qa",
+    mode: "inline",
+    description: "Valida aderência da peça à identidade da empresa"
+  },
+  {
+    slug: "delivery-qa",
+    mode: "inline",
+    description: "Valida export, pacing e readiness de entrega"
+  },
+  {
+    slug: "paperclip-composer",
+    mode: "script",
+    description: "Composição declarativa de layouts, timelines e overlays"
+  },
+  {
+    slug: "ffmpeg-render",
+    mode: "script",
+    description: "Render, transformações de mídia e extração de previews"
+  },
+  {
+    slug: "publish-dry-run",
+    mode: "script",
+    description: "Empacota publicação em modo dry-run e gera receipts"
+  },
+  {
     slug: "ga4",
     mode: "python",
     description: "Analytics do site e funil da Doze"

--- a/research/architecture/README.md
+++ b/research/architecture/README.md
@@ -8,3 +8,5 @@ Trilha para critérios de qualidade, opções de control plane, arquitetura alvo
 - `control-plane-options.md`
 - `architecture-target.md`
 - `creative-workflow-reference-architecture.md`
+- `creative-agent-contracts.md`
+- `creative-squad-manifests.md`

--- a/research/architecture/creative-agent-contracts.md
+++ b/research/architecture/creative-agent-contracts.md
@@ -1,0 +1,200 @@
+<!-- TEMPLATE: EVIDENCE | version: 1.0 | do not remove this line -->
+
+# Creative Agent Contracts
+
+> **Status:** TASK-038 / implementable contract baseline
+> **Goal:** transformar a arquitetura criativa em contratos públicos mínimos e coerentes com a superfície atual do OpenClow
+
+## Intent
+
+Este documento define o contrato mínimo entre os agentes do sistema criativo.
+O objetivo não é detalhar toda a implementação futura, e sim fixar o que precisa existir para que o `product/` possa começar a executar o primeiro corte do workflow criativo sem quebrar os contracts já publicados.
+
+## Contract Set
+
+### `brand_context.json`
+
+Responsável por consolidar:
+- `brand profile`
+- `operational truth`
+- `campaign context`
+- `creative playbook`
+
+Campos mínimos:
+- `workspace_slug`
+- `brand_slug`
+- `campaign_slug`
+- `channel`
+- `context_precedence`
+- `constraints`
+- `allowed_tools`
+
+### `reference_pack.json`
+
+Responsável por reunir:
+- referências explícitas do usuário
+- referências coletadas automaticamente
+- sinais de estilo
+- anti-patterns
+
+Campos mínimos:
+- `reference_urls`
+- `reference_assets`
+- `style_signals`
+- `visual_anti_patterns`
+- `confidence`
+
+### `creative_intent.json`
+
+Responsável por traduzir o objetivo criativo em direção executável.
+
+Campos mínimos:
+- `intent_kind`
+- `objective`
+- `audience`
+- `channel`
+- `format`
+- `narrative_arc`
+- `quality_bar`
+- `approval_requirements`
+
+### `asset_plan.json`
+
+Responsável por decidir a origem dos assets.
+
+Campos mínimos:
+- `asset_sources`
+- `reuse_existing_assets`
+- `needs_generation`
+- `needs_compositing`
+- `needs_cleanup`
+- `machine_profile`
+
+### `shot_plan.json`
+
+Responsável por quebrar o vídeo em shots aprováveis.
+
+Campos mínimos:
+- `shots`
+- `timing_strategy`
+- `camera_language`
+- `type_treatment`
+- `qa_gate`
+
+### `edit_decision_list.json`
+
+Responsável por representar a timeline executável.
+
+Campos mínimos:
+- `clips`
+- `transitions`
+- `sync_points`
+- `preview_points`
+
+### `vfx_plan.json`
+
+Responsável por definir acabamento e intensidade.
+
+Campos mínimos:
+- `grade`
+- `overlays`
+- `distortion_controls`
+- `masking`
+- `text_effects`
+- `effect_intensity`
+
+### `qa_report_brand.json`
+
+Responsável por responder:
+- a peça parece excelente para esta empresa?
+
+Campos mínimos:
+- `status`
+- `score`
+- `issues`
+- `reasons_for_reject`
+- `retry_guidance`
+
+### `qa_report_delivery.json`
+
+Responsável por responder:
+- a peça está pronta para entrega/publicação?
+
+Campos mínimos:
+- `status`
+- `technical_score`
+- `export_readiness`
+- `issues`
+- `retry_guidance`
+
+### `approval_packet.json`
+
+Responsável por consolidar o que o humano precisa aprovar.
+
+Campos mínimos:
+- `target_kind`
+- `run_id`
+- `artifacts`
+- `brand_qa_status`
+- `delivery_qa_status`
+- `publication_risk_level`
+
+## Contract Placement in Public Schemas
+
+Os contracts acima não precisam virar endpoints dedicados neste corte.
+Eles precisam ser suportados pelos contratos públicos existentes através destes campos:
+
+- `Capability`
+  - `system_family`
+  - `machine_profile`
+  - `environment_scope`
+  - `supports_dry_run`
+  - `requires_checkpoint`
+  - `artifact_contracts`
+
+- `Squad`
+  - `system_family`
+  - `machine_profile`
+  - `environment_scope`
+  - `context_precedence`
+  - `qa_capability_ids`
+
+- `Pipeline`
+  - `name`
+  - `workspace_slug`
+  - `machine_profile`
+  - `environment_scope`
+
+- `Step`
+  - `label`
+  - `tool_slugs`
+  - `optional_tool_slugs`
+  - `input_contracts`
+  - `output_contracts`
+  - `machine_profile`
+  - `environment_scope`
+  - `qa_gate`
+  - `risk_level`
+
+- `Run`
+  - `intent_kind`
+  - `machine_profile`
+  - `environment_scope`
+  - `requested_capability_ids`
+
+## First Implementable Cut
+
+O primeiro corte implementável não deve começar pelo pipeline completo de vídeo.
+
+Ele deve começar por:
+1. `creative-control`
+2. `reference-lab`
+3. `creative-qa`
+
+Com isso o produto já consegue:
+- consolidar contexto
+- ingerir e enriquecer referências
+- produzir e validar `creative_intent.json`
+- abrir approvals fortes antes de renderização final
+
+`creative-image` e `creative-video` entram no corte seguinte, já com contracts estáveis.

--- a/research/architecture/creative-squad-manifests.md
+++ b/research/architecture/creative-squad-manifests.md
@@ -1,0 +1,185 @@
+<!-- TEMPLATE: EVIDENCE | version: 1.0 | do not remove this line -->
+
+# Creative Squad Manifests
+
+> **Status:** TASK-038 / manifest baseline
+> **Goal:** definir os manifests iniciais de squads, skills e tools especializados para o sistema criativo
+
+## Intent
+
+Este documento fixa o recorte inicial de `squads`, `skills` e `tools` que devem existir no OpenClow para desenvolver o sistema criativo de forma progressiva.
+
+O foco é o primeiro corte implementável, não a cobertura completa do roadmap.
+
+## Initial Squads
+
+### `creative-control`
+
+**Role**
+- orquestra o workflow
+- resolve contexto
+- decide o fluxo
+- consolida approvals
+
+**Required capabilities**
+- `brand-context-orchestrator`
+- `creative-director`
+- `approval-gatekeeper`
+
+**Environment**
+- `local-dev`
+- `staging`
+
+**Machine profile**
+- `balanced`
+
+### `reference-lab`
+
+**Role**
+- recebe referências
+- pesquisa referências adicionais
+- enriquece o estilo
+
+**Required capabilities**
+- `reference-fetcher`
+- `reference-enricher`
+- `style-signal-extractor`
+
+**Environment**
+- `local-dev`
+- `staging`
+
+**Machine profile**
+- `balanced`
+
+### `creative-qa`
+
+**Role**
+- faz QA de marca e de entrega
+- gera score e motivos de rejeição
+
+**Required capabilities**
+- `brand-qa`
+- `delivery-qa`
+
+**Environment**
+- `local-dev`
+- `staging`
+
+**Machine profile**
+- `cpu-safe`
+
+### `creative-image`
+
+**Role**
+- compõe imagem estática, carrossel e stories estáticos
+
+**Required capabilities**
+- `paperclip-composer`
+- `asset-strategist`
+- `preview-extractor`
+
+**Environment**
+- `local-dev`
+- `staging`
+
+**Machine profile**
+- `balanced`
+
+### `creative-video`
+
+**Role**
+- compõe vídeo vertical curto
+
+**Required capabilities**
+- `frame-planner`
+- `motion-editor`
+- `vfx-finisher`
+- `ffmpeg-render`
+
+**Environment**
+- `local-dev`
+- `staging`
+
+**Machine profile**
+- `balanced`
+
+### `publishing-control`
+
+**Role**
+- empacota para publicação ou agendamento
+- roda somente após gate
+
+**Required capabilities**
+- `publish-dry-run`
+- `publication-gatekeeper`
+
+**Environment**
+- `staging`
+- `production`
+
+**Machine profile**
+- `cpu-safe`
+
+## Initial Skill/Tool Set
+
+### Core control
+- `brand-context-orchestrator`
+- `creative-director`
+- `approval-gatekeeper`
+
+### References
+- `reference-fetcher`
+- `reference-enricher`
+- `style-signal-extractor`
+
+### Composition
+- `paperclip-composer`
+- `asset-strategist`
+- `frame-planner`
+
+### Render and finishing
+- `motion-editor`
+- `vfx-finisher`
+- `ffmpeg-render`
+- `preview-extractor`
+
+### QA
+- `brand-qa`
+- `delivery-qa`
+
+### Publishing
+- `publish-dry-run`
+- `publication-gatekeeper`
+
+## First Product Cut
+
+### What should be seeded now
+
+- creative capabilities in `product/packages/shared/src/seeds.js`
+- creative skill catalog entries in `product/packages/skills/src/catalog.js`
+- public schemas updated in `product/packages/shared/contracts/v1/`
+
+### What should be implemented next
+
+1. `creative-control` seed
+2. `reference-lab` seed
+3. `creative-qa` seed
+4. endpoint/document contract alignment
+
+### What stays for the next cut
+
+1. full `creative-image` execution
+2. full `creative-video` execution
+3. publishing integration beyond dry-run
+4. server deployment path
+
+## Production Boundary
+
+Mesmo com esses manifests prontos, o sistema ainda não está pronto para subir direto no servidor de produção.
+
+Antes disso ainda faltam:
+- staging comprovado
+- política de segredos do serviço
+- rollout/rollback do serviço criativo
+- validação dos perfis de máquina no ambiente-alvo

--- a/workboard/BACKLOG.md
+++ b/workboard/BACKLOG.md
@@ -14,17 +14,17 @@
 
 ### P1 — Alta Prioridade
 
-### TASK-038 | Transformar a arquitetura criativa em contracts e seeds implementáveis
+### TASK-039 | Implementar o primeiro corte do sistema criativo em `product/`
 - **Tipo:** research
 - **Prioridade:** P1
 - **Tamanho:** M
 - **Status:** `backlog`
-- **Objetivo:** converter a arquitetura de referência dos workflows criativos em contracts públicos, manifests de squads/skills/tools e backlog de implementação dentro de `product/`.
-- **Dependências:** TASK-037 concluída
+- **Objetivo:** implementar no produto o primeiro corte criativo já definido por `TASK-038`: `creative-control`, `reference-lab` e `creative-qa`, com seeds, contracts e leitura básica via API/dashboard.
+- **Dependências:** TASK-038 concluída
 - **Output esperado:**
-  - `research/architecture/creative-agent-contracts.md`
-  - `research/architecture/creative-squad-manifests.md`
-  - recomendação de alterações em `product/packages/shared/contracts/v1/`
-  - definição do primeiro corte implementável em `product/`
+  - atualização do runtime e da API para expor os squads criativos seeded
+  - primeiro fluxo criativo consultável e iniciável no `product/`
+  - harness ou smoke test cobrindo o fluxo básico de contexto → referência → QA
+  - documentação de uso local/staging do corte criativo inicial
 
 ## Backlog do Squad 1 (a ser preenchido pelo Squad 0 via TASK-015)

--- a/workboard/DONE.md
+++ b/workboard/DONE.md
@@ -21,6 +21,33 @@
 
 ## Histórico
 
+### TASK-038 | Transformar a arquitetura criativa em contracts e seeds implementáveis
+- **Concluída em:** 2026-04-24
+- **Por:** codex
+- **Issue:** #20 (fechada)
+- **Branch:** task/20-creative-contracts-manifests
+- **Output produzido:**
+  - `research/architecture/creative-agent-contracts.md`
+  - `research/architecture/creative-squad-manifests.md`
+  - `research/architecture/README.md`
+  - `product/packages/shared/contracts/v1/capability.schema.json`
+  - `product/packages/shared/contracts/v1/squad.schema.json`
+  - `product/packages/shared/contracts/v1/pipeline.schema.json`
+  - `product/packages/shared/contracts/v1/step.schema.json`
+  - `product/packages/shared/contracts/v1/run.schema.json`
+  - `product/packages/shared/contracts/v1/checkpoint.schema.json`
+  - `product/packages/shared/contracts/v1/approval.schema.json`
+  - `product/packages/shared/contracts/v1/openclow-api.yaml`
+  - `product/packages/shared/src/contracts.js`
+  - `product/packages/shared/src/seeds.js`
+  - `product/packages/skills/src/catalog.js`
+  - `workboard/BACKLOG.md`
+  - `workboard/IN_PROGRESS.md`
+  - `workboard/DONE.md`
+  - `handoffs/ACTIVE.md`
+  - `handoffs/snapshots/2026-04-24-codex-task-038-complete.md`
+- **Notas:** O produto agora tem contratos públicos e seeds iniciais para a trilha criativa. O próximo corte já pode entrar em implementação real no `product/`, ainda sob boundary de `local-dev` e `staging`.
+
 ### TASK-037 | Traduzir a pesquisa de campo em arquitetura de referência para workflows criativos
 - **Concluída em:** 2026-04-24
 - **Por:** codex


### PR DESCRIPTION
## Summary
- transforma a arquitetura criativa em contracts públicos e manifests iniciais
- expande os schemas compartilhados e o catálogo/seed do produto para a trilha criativa
- deixa explícito o primeiro corte implementável em `product/` sem liberar produção por default

## Testing
- `npm --prefix product run check`

Closes #20