### PR TITLE
TASK-039: implementa o primeiro corte do sistema criativo

### DIFF
--- a/handoffs/ACTIVE.md
+++ b/handoffs/ACTIVE.md
@@ -8,7 +8,7 @@
 ## Estado do Bastão
 
 - **baton:** UNASSIGNED
-- **last-updated-by:** codex (task 038 completed)
+- **last-updated-by:** codex (task 039 completed)
 - **last-updated-at:** 2026-04-24
 - **last-read-by:** codex
 - **last-read-at:** 2026-04-24
@@ -17,34 +17,34 @@
 
 ## Tasks em Voo
 
-1. TASK-038 concluída com contracts e seeds implementáveis para a trilha criativa.
-2. Próximo passo: iniciar `TASK-039` no backlog.
+1. TASK-039 concluída com o primeiro corte criativo implementado em `product/`.
+2. Próximo passo: iniciar `TASK-040` no backlog.
 
 ---
 
 ## Última Ação Completada
 
-Fechamento da TASK-038 com contracts públicos e seeds iniciais do sistema criativo.
+Fechamento da TASK-039 com o primeiro fluxo criativo seeded executando no produto.
 
 **Mudanças concluídas nesta sessão:**
-- `research/architecture/creative-agent-contracts.md` criado
-- `research/architecture/creative-squad-manifests.md` criado
-- schemas de `product/packages/shared/contracts/v1/` expandidos para a trilha criativa
-- `product/packages/shared/src/seeds.js` atualizado com squads e capabilities criativas iniciais
-- `product/packages/skills/src/catalog.js` atualizado com skills criativas iniciais
-- `product/packages/shared/contracts/v1/openclow-api.yaml` alinhado com a superfície atual
+- `product/packages/orchestrator/src/service.js` atualizado para expor metadados dos squads criativos
+- `product/packages/runtime/src/service.js` atualizado para persistir outputs do fluxo criativo seeded
+- `product/packages/tools/src/runner.js` atualizado com bindings criativos mínimos
+- `product/tests/e2e/run.mjs` atualizado para cobrir o cenário criativo
+- `product/README.md` atualizado para documentar o primeiro corte criativo
 - `npm --prefix product run check` executado com sucesso
-- `workboard/BACKLOG.md` atualizado com `TASK-039`
+- `npm --prefix product run regression` executado com sucesso
+- `workboard/BACKLOG.md` atualizado com `TASK-040`
 - `workboard/IN_PROGRESS.md` zerado
-- `workboard/DONE.md` atualizado para incluir `TASK-038`
-- `handoffs/ACTIVE.md` reconciliado para refletir o fechamento da TASK-038
+- `workboard/DONE.md` atualizado para incluir `TASK-039`
+- `handoffs/ACTIVE.md` reconciliado para refletir o fechamento da TASK-039
 
 ---
 
 ## Próxima Ação Recomendada
 
-1. Iniciar `TASK-039`
-2. Implementar o primeiro corte criativo em `product/`
+1. Iniciar `TASK-040`
+2. Implementar `creative-image` como primeiro fluxo renderizável
 3. Manter staging-first antes de qualquer passo ligado ao servidor de produção
 
 **Papéis recomendados para a próxima sessão:** `Program Architect`, `Workflow Field Researcher`
@@ -59,7 +59,7 @@ NENHUM.
 
 ## Snapshot de Contexto
 
-`handoffs/snapshots/2026-04-24-codex-task-038-complete.md`
+`handoffs/snapshots/2026-04-24-codex-task-039-complete.md`
 
 ---
 
@@ -73,8 +73,8 @@ O repositório agora tem duas camadas ativas e coerentes:
 - o registry agora tem lifecycle formal e approvals explícitos
 
 **O que fazer a seguir:**
-- iniciar `TASK-039`
-- implementar o primeiro corte criativo seeded em `product/`
+- iniciar `TASK-040`
+- usar o corte seeded atual como base para renderização de `creative-image`
 - seguir preservando o fluxo operacional atual da Doze e o guardrail de staging-first
 
 **Próximo agente recomendado:** `Program Architect` com apoio de `Workflow Field Researcher`

--- a/handoffs/snapshots/2026-04-24-codex-task-039-complete.md
+++ b/handoffs/snapshots/2026-04-24-codex-task-039-complete.md
@@ -1,0 +1,26 @@
+# Snapshot — TASK-039
+
+**Data:** 2026-04-24  
+**Agente:** codex  
+**Branch:** `task/22-creative-first-cut`  
+**Issue:** `#22`
+
+## Objetivo
+
+Implementar no `product/` o primeiro corte do sistema criativo seeded, cobrindo `creative-control`, `reference-lab` e `creative-qa`.
+
+## Entregas
+
+- `orchestrator` agora expõe metadados dos squads criativos
+- `runtime` executa o fluxo criativo seeded com outputs persistidos
+- `tool runner` ganhou bindings criativos mínimos
+- a regressão E2E cobre contexto -> referência -> QA
+
+## Validação
+
+- `npm --prefix product run check`
+- `npm --prefix product run regression`
+
+## Próxima ação recomendada
+
+Iniciar `TASK-040` para implementar `creative-image` como primeiro fluxo criativo renderizável com `paperclip-composer` e `ffmpeg-render`.

--- a/product/README.md
+++ b/product/README.md
@@ -54,3 +54,22 @@ Eles definem o wire contract inicial para:
 - API mínima do MVP
 
 Esses contratos já reservam espaço para identificar o workspace/empresa associado a squads, capabilities e runs, porque o modo atual de operação da Doze não é single-context.
+
+## Primeiro corte criativo
+
+O baseline do produto agora também inclui o primeiro corte da trilha criativa:
+
+- `creative-control`
+- `reference-lab`
+- `creative-qa`
+
+Neste corte:
+- os squads já existem como seeds do produto
+- o fluxo básico `contexto -> referencia -> QA` já pode ser iniciado localmente
+- o objetivo ainda é `local-dev` e `staging`
+- produção continua fora do caminho default
+
+O que ainda nao entra neste corte:
+- deploy no servidor de produção
+- publicação real por default
+- pipeline completa de imagem e vídeo final

--- a/product/packages/orchestrator/src/service.js
+++ b/product/packages/orchestrator/src/service.js
@@ -25,7 +25,10 @@ export class OrchestratorService {
       name: squad.name,
       workspace_slug: squad.workspace_slug,
       version: squad.version,
-      default_model_tier: squad.default_model_tier
+      default_model_tier: squad.default_model_tier,
+      system_family: squad.system_family ?? "core",
+      machine_profile: squad.machine_profile ?? null,
+      environment_scope: squad.environment_scope ?? null
     }));
   }
 
@@ -44,12 +47,17 @@ export class OrchestratorService {
       squad_slug: squad.slug,
       pipeline_id: squad.pipeline_id,
       workspace_slug: input.workspace_slug ?? squad.workspace_slug,
+      intent_kind: input.intent_kind ?? null,
+      machine_profile: input.machine_profile ?? squad.machine_profile ?? null,
+      environment_scope: input.environment_scope ?? squad.environment_scope ?? null,
       status: "queued",
       requested_at: new Date().toISOString(),
       started_at: null,
       completed_at: null,
       current_step_id: null,
       requested_by: input.requested_by ?? "unknown",
+      request_context: input.request_context ?? {},
+      requested_capability_ids: input.requested_capability_ids ?? [],
       history: [
         {
           at: new Date().toISOString(),
@@ -69,16 +77,19 @@ export class OrchestratorService {
       this.store.queue.push(run.id);
     }
     this.recordAuditEvent({
-      event: "run.requested",
-      subject_kind: "run",
-      subject_id: run.id,
-      actor: run.requested_by,
-      workspace_slug: run.workspace_slug,
-      details: {
-        squad_slug: run.squad_slug,
-        pipeline_id: run.pipeline_id
-      }
-    });
+        event: "run.requested",
+        subject_kind: "run",
+        subject_id: run.id,
+        actor: run.requested_by,
+        workspace_slug: run.workspace_slug,
+        details: {
+          squad_slug: run.squad_slug,
+          pipeline_id: run.pipeline_id,
+          intent_kind: run.intent_kind,
+          machine_profile: run.machine_profile,
+          environment_scope: run.environment_scope
+        }
+      });
     this.store.persist?.();
     return run;
   }

--- a/product/packages/runtime/src/service.js
+++ b/product/packages/runtime/src/service.js
@@ -292,20 +292,16 @@ export class RuntimeService {
   }
 
   executeStep(step, run) {
-    if (step.kind === "tool" || step.executor === "tool-runner" || step.executor === "subagent") {
+    if (
+      step.kind === "tool" ||
+      step.executor === "tool-runner" ||
+      step.executor === "subagent" ||
+      (Array.isArray(step.tool_slugs) && step.tool_slugs.length > 0)
+    ) {
       return this.executeToolStep(step, run);
     }
 
-    return [
-      {
-        id: createId(),
-        step_id: step.id,
-        run_id: run.id,
-        created_at: new Date().toISOString(),
-        summary: `${step.label} executado em modo local de desenvolvimento`,
-        artifact_type: "text_note"
-      }
-    ];
+    return this.buildPromptOutputs(step, run);
   }
 
   executeToolStep(step, run) {
@@ -342,7 +338,11 @@ export class RuntimeService {
         run_id: run.id,
         squad_slug: run.squad_slug,
         workspace_slug: run.workspace_slug,
-        step_id: step.id
+        step_id: step.id,
+        request_context: run.request_context,
+        machine_profile: run.machine_profile,
+        environment_scope: run.environment_scope,
+        intent_kind: run.intent_kind
       });
 
       outputs.push({
@@ -375,7 +375,11 @@ export class RuntimeService {
         run_id: run.id,
         squad_slug: run.squad_slug,
         workspace_slug: run.workspace_slug,
-        step_id: step.id
+        step_id: step.id,
+        request_context: run.request_context,
+        machine_profile: run.machine_profile,
+        environment_scope: run.environment_scope,
+        intent_kind: run.intent_kind
       });
 
       outputs.push({
@@ -390,6 +394,59 @@ export class RuntimeService {
     }
 
     return outputs;
+  }
+
+  buildPromptOutputs(step, run) {
+    const contracts = step.output_contracts ?? [];
+
+    if (contracts.length === 0) {
+      return [
+        {
+          id: createId(),
+          step_id: step.id,
+          run_id: run.id,
+          created_at: new Date().toISOString(),
+          summary: `${step.label} executado em modo local de desenvolvimento`,
+          artifact_type: "text_note"
+        }
+      ];
+    }
+
+    return contracts.map((contractName) => ({
+      id: createId(),
+      step_id: step.id,
+      run_id: run.id,
+      created_at: new Date().toISOString(),
+      artifact_type: this.contractToArtifactType(contractName),
+      summary: this.buildContractSummary(step, contractName, run),
+      details: {
+        contract: contractName,
+        machine_profile: step.machine_profile ?? run.machine_profile ?? null,
+        environment_scope: step.environment_scope ?? run.environment_scope ?? null,
+        intent_kind: run.intent_kind ?? null,
+        request_context: run.request_context ?? {}
+      }
+    }));
+  }
+
+  contractToArtifactType(contractName) {
+    return contractName.replace(/\.json$/u, "").replace(/[^a-z0-9]+/giu, "_");
+  }
+
+  buildContractSummary(step, contractName, run) {
+    const contractLabelMap = {
+      "creative_intent.json": "Intento criativo consolidado",
+      "approval_packet.json": "Pacote de aprovacao preparado",
+      "brand_context.json": "Contexto de marca consolidado",
+      "reference_pack.json": "Pacote de referencias consolidado",
+      "style_signals.json": "Sinais visuais extraidos",
+      "visual_anti_patterns.json": "Anti-patterns visuais registrados",
+      "qa_report_brand.json": "QA de identidade executado",
+      "qa_report_delivery.json": "QA tecnico executado"
+    };
+
+    const label = contractLabelMap[contractName] ?? `${contractName} gerado`;
+    return `${label} para ${run.squad_slug} em ${step.id}`;
   }
 
   inferToolSlugs(step, run) {

--- a/product/packages/tools/src/runner.js
+++ b/product/packages/tools/src/runner.js
@@ -106,7 +106,123 @@ function buildBlotatoArtifact(context) {
   };
 }
 
+function buildBrandContextArtifact(context) {
+  return {
+    tool: "brand-context-orchestrator",
+    artifact_type: "brand_context",
+    summary: `Contexto consolidado para ${context.squad_slug}`,
+    details: {
+      workspace: context.workspace_slug,
+      brand_slug: context.request_context?.brand_slug ?? "doze-crew",
+      campaign_slug: context.request_context?.campaign_slug ?? "creative-baseline",
+      machine_profile: context.machine_profile ?? "cpu-safe",
+      environment_scope: context.environment_scope ?? "local-dev"
+    }
+  };
+}
+
+function buildReferenceFetcherArtifact(context) {
+  const referenceUrls = context.request_context?.reference_urls ?? [];
+
+  return {
+    tool: "reference-fetcher",
+    artifact_type: "reference_pack",
+    summary: `Referencias ingeridas para ${context.squad_slug}`,
+    details: {
+      workspace: context.workspace_slug,
+      reference_count: referenceUrls.length,
+      reference_urls: referenceUrls
+    }
+  };
+}
+
+function buildReferenceEnricherArtifact(context) {
+  const styleDirection = context.request_context?.style_direction ?? "modern-underground";
+
+  return {
+    tool: "reference-enricher",
+    artifact_type: "style_signals",
+    summary: `Sinais visuais enriquecidos para ${context.squad_slug}`,
+    details: {
+      workspace: context.workspace_slug,
+      style_direction: styleDirection,
+      anti_patterns: ["generic-stock-look", "weak-contrast", "template-motion"]
+    }
+  };
+}
+
+function buildBrandQaArtifact(context) {
+  return {
+    tool: "brand-qa",
+    artifact_type: "brand_qa",
+    summary: `QA de identidade executado para ${context.squad_slug}`,
+    details: {
+      workspace: context.workspace_slug,
+      score: 8.4,
+      status: "approved-with-notes"
+    }
+  };
+}
+
+function buildDeliveryQaArtifact(context) {
+  return {
+    tool: "delivery-qa",
+    artifact_type: "delivery_qa",
+    summary: `QA tecnico executado para ${context.squad_slug}`,
+    details: {
+      workspace: context.workspace_slug,
+      export_readiness: "staging-ready",
+      status: "approved-with-notes"
+    }
+  };
+}
+
+function buildPaperclipComposerArtifact(context) {
+  return {
+    tool: "paperclip-composer",
+    artifact_type: "composition_plan",
+    summary: `Composicao declarativa preparada para ${context.squad_slug}`,
+    details: {
+      workspace: context.workspace_slug,
+      machine_profile: context.machine_profile ?? "balanced"
+    }
+  };
+}
+
+function buildFfmpegRenderArtifact(context) {
+  return {
+    tool: "ffmpeg-render",
+    artifact_type: "preview_manifest",
+    summary: `Manifesto de previews preparado para ${context.squad_slug}`,
+    details: {
+      workspace: context.workspace_slug,
+      environment_scope: context.environment_scope ?? "staging"
+    }
+  };
+}
+
+function buildPublishDryRunArtifact(context) {
+  return {
+    tool: "publish-dry-run",
+    artifact_type: "publish_receipt",
+    summary: `Dry-run de publicacao preparado para ${context.squad_slug}`,
+    details: {
+      workspace: context.workspace_slug,
+      mode: "dry-run",
+      destination: context.request_context?.channel ?? "instagram"
+    }
+  };
+}
+
 const toolHandlers = {
+  "brand-context-orchestrator": buildBrandContextArtifact,
+  "reference-fetcher": buildReferenceFetcherArtifact,
+  "reference-enricher": buildReferenceEnricherArtifact,
+  "brand-qa": buildBrandQaArtifact,
+  "delivery-qa": buildDeliveryQaArtifact,
+  "paperclip-composer": buildPaperclipComposerArtifact,
+  "ffmpeg-render": buildFfmpegRenderArtifact,
+  "publish-dry-run": buildPublishDryRunArtifact,
   ga4: buildGa4Artifact,
   woocommerce: buildWooCommerceArtifact,
   "meta-insights": buildMetaInsightsArtifact,

--- a/product/tests/e2e/run.mjs
+++ b/product/tests/e2e/run.mjs
@@ -259,6 +259,127 @@ async function runIntelligenceScenario() {
   return run.id;
 }
 
+async function runCreativeScenario() {
+  log("creative scenario");
+
+  const squads = await requestJson("/v1/squads");
+  assert(
+    squads.items.some((item) => item.slug === "creative-control"),
+    "Creative control squad should be listed by the API"
+  );
+  assert(
+    squads.items.some((item) => item.slug === "reference-lab"),
+    "Reference lab squad should be listed by the API"
+  );
+  assert(
+    squads.items.some((item) => item.slug === "creative-qa"),
+    "Creative QA squad should be listed by the API"
+  );
+
+  const referenceRun = await requestJson("/v1/runs", {
+    method: "POST",
+    body: JSON.stringify({
+      squad_slug: "reference-lab",
+      workspace_slug: "doze",
+      requested_by: "e2e",
+      intent_kind: "creative-image",
+      machine_profile: "balanced",
+      environment_scope: "local-dev",
+      request_context: {
+        brand_slug: "doze-crew",
+        campaign_slug: "spring-drop",
+        reference_urls: [
+          "https://example.com/ref-1",
+          "https://example.com/ref-2"
+        ],
+        style_direction: "modern-underground"
+      }
+    })
+  });
+
+  const completedReference = await driveCheckpointedRun(referenceRun.id, { expectedCheckpoints: 0 });
+  assert(completedReference.status === "succeeded", "Reference lab run did not finish successfully");
+
+  const referenceOutputs = await requestJson(`/v1/runs/${referenceRun.id}/outputs`);
+  assert(
+    referenceOutputs.items.some((item) => item.artifact_type === "reference_pack"),
+    "Reference lab should produce a reference pack artifact"
+  );
+  assert(
+    referenceOutputs.items.some((item) => item.artifact_type === "style_signals"),
+    "Reference lab should produce style signals"
+  );
+
+  const controlRun = await requestJson("/v1/runs", {
+    method: "POST",
+    body: JSON.stringify({
+      squad_slug: "creative-control",
+      workspace_slug: "doze",
+      requested_by: "e2e",
+      intent_kind: "creative-image",
+      machine_profile: "balanced",
+      environment_scope: "staging",
+      request_context: {
+        brand_slug: "doze-crew",
+        campaign_slug: "spring-drop",
+        channel: "instagram",
+        style_direction: "modern-underground"
+      }
+    })
+  });
+
+  const completedControl = await driveCheckpointedRun(controlRun.id, { expectedCheckpoints: 1 });
+  assert(completedControl.status === "succeeded", "Creative control run did not finish successfully");
+
+  const controlOutputs = await requestJson(`/v1/runs/${controlRun.id}/outputs`);
+  assert(
+    controlOutputs.items.some((item) => item.artifact_type === "brand_context"),
+    "Creative control should produce brand context"
+  );
+  assert(
+    controlOutputs.items.some((item) => item.artifact_type === "creative_intent"),
+    "Creative control should produce creative intent"
+  );
+  assert(
+    controlOutputs.items.some((item) => item.artifact_type === "approval_packet"),
+    "Creative control should produce approval packet"
+  );
+
+  const qaRun = await requestJson("/v1/runs", {
+    method: "POST",
+    body: JSON.stringify({
+      squad_slug: "creative-qa",
+      workspace_slug: "doze",
+      requested_by: "e2e",
+      intent_kind: "creative-image",
+      machine_profile: "cpu-safe",
+      environment_scope: "staging",
+      request_context: {
+        channel: "instagram"
+      }
+    })
+  });
+
+  const completedQa = await driveCheckpointedRun(qaRun.id, { expectedCheckpoints: 1 });
+  assert(completedQa.status === "succeeded", "Creative QA run did not finish successfully");
+
+  const qaOutputs = await requestJson(`/v1/runs/${qaRun.id}/outputs`);
+  assert(
+    qaOutputs.items.some((item) => item.artifact_type === "brand_qa"),
+    "Creative QA should produce brand QA output"
+  );
+  assert(
+    qaOutputs.items.some((item) => item.artifact_type === "delivery_qa"),
+    "Creative QA should produce delivery QA output"
+  );
+
+  return {
+    referenceRunId: referenceRun.id,
+    controlRunId: controlRun.id,
+    qaRunId: qaRun.id
+  };
+}
+
 async function runPromotionScenario() {
   log("promotion scenario");
   const capability = await requestJson("/v1/capabilities", {
@@ -383,6 +504,7 @@ async function main() {
 
     const marketingRunId = await runMarketingScenario();
     const intelligenceRunId = await runIntelligenceScenario();
+    const creativeRuns = await runCreativeScenario();
     await runPromotionScenario();
     const restartedApi = await runRestartRecoveryScenario(apiProcess);
 
@@ -407,6 +529,7 @@ async function main() {
 
     log(`marketing run: ${marketingRunId}`);
     log(`intelligence run: ${intelligenceRunId}`);
+    log(`creative runs: ${creativeRuns.referenceRunId}, ${creativeRuns.controlRunId}, ${creativeRuns.qaRunId}`);
     log("all scenarios passed");
 
     await stop(dashboardProcess);

--- a/workboard/BACKLOG.md
+++ b/workboard/BACKLOG.md
@@ -14,17 +14,17 @@
 
 ### P1 — Alta Prioridade
 
-### TASK-039 | Implementar o primeiro corte do sistema criativo em `product/`
+### TASK-040 | Implementar `creative-image` como primeiro fluxo criativo renderizável
 - **Tipo:** research
 - **Prioridade:** P1
 - **Tamanho:** M
 - **Status:** `backlog`
-- **Objetivo:** implementar no produto o primeiro corte criativo já definido por `TASK-038`: `creative-control`, `reference-lab` e `creative-qa`, com seeds, contracts e leitura básica via API/dashboard.
-- **Dependências:** TASK-038 concluída
+- **Objetivo:** estender o corte criativo atual para executar o primeiro fluxo renderizável de imagem estática/carrossel com `paperclip-composer`, `ffmpeg-render` e QA já seeded.
+- **Dependências:** TASK-039 concluída
 - **Output esperado:**
-  - atualização do runtime e da API para expor os squads criativos seeded
-  - primeiro fluxo criativo consultável e iniciável no `product/`
-  - harness ou smoke test cobrindo o fluxo básico de contexto → referência → QA
-  - documentação de uso local/staging do corte criativo inicial
+  - fluxo `creative-image` implementado no `product/`
+  - artifacts e previews renderizáveis persistidos
+  - regressão cobrindo o fluxo de imagem
+  - documentação local/staging do primeiro fluxo renderizável
 
 ## Backlog do Squad 1 (a ser preenchido pelo Squad 0 via TASK-015)

--- a/workboard/DONE.md
+++ b/workboard/DONE.md
@@ -21,6 +21,24 @@
 
 ## Histórico
 
+### TASK-039 | Implementar o primeiro corte do sistema criativo em `product/`
+- **Concluída em:** 2026-04-24
+- **Por:** codex
+- **Issue:** #22 (fechada)
+- **Branch:** task/22-creative-first-cut
+- **Output produzido:**
+  - `product/packages/orchestrator/src/service.js`
+  - `product/packages/runtime/src/service.js`
+  - `product/packages/tools/src/runner.js`
+  - `product/tests/e2e/run.mjs`
+  - `product/README.md`
+  - `workboard/BACKLOG.md`
+  - `workboard/IN_PROGRESS.md`
+  - `workboard/DONE.md`
+  - `handoffs/ACTIVE.md`
+  - `handoffs/snapshots/2026-04-24-codex-task-039-complete.md`
+- **Notas:** O produto agora expõe e executa o primeiro corte criativo seeded (`creative-control`, `reference-lab`, `creative-qa`) com outputs persistidos e regressão passando junto com marketing e inteligência.
+
 ### TASK-038 | Transformar a arquitetura criativa em contracts e seeds implementáveis
 - **Concluída em:** 2026-04-24
 - **Por:** codex


### PR DESCRIPTION
## Summary
- implementa no produto o primeiro corte criativo seeded (`creative-control`, `reference-lab`, `creative-qa`)
- adiciona bindings mínimos, outputs persistidos e metadados de squads criativos
- cobre o fluxo criativo básico na regressão junto com marketing e inteligência

## Testing
- `npm --prefix product run check`
- `npm --prefix product run regression`

Closes #22