### PR TITLE
TASK-040: implementar creative-image como primeiro fluxo renderizável

### DIFF
--- a/handoffs/ACTIVE.md
+++ b/handoffs/ACTIVE.md
@@ -8,7 +8,7 @@
 ## Estado do Bastão
 
 - **baton:** UNASSIGNED
-- **last-updated-by:** codex (task 039 completed)
+- **last-updated-by:** codex (task 040 completed)
 - **last-updated-at:** 2026-04-24
 - **last-read-by:** codex
 - **last-read-at:** 2026-04-24
@@ -17,34 +17,34 @@
 
 ## Tasks em Voo
 
-1. TASK-039 concluída com o primeiro corte criativo implementado em `product/`.
-2. Próximo passo: iniciar `TASK-040` no backlog.
+1. TASK-040 concluída com o primeiro fluxo renderizável de imagem em `product/`.
+2. Próximo passo: iniciar `TASK-041` no backlog.
 
 ---
 
 ## Última Ação Completada
 
-Fechamento da TASK-039 com o primeiro fluxo criativo seeded executando no produto.
+Fechamento da TASK-040 com `creative-image` implementado e regressão verde.
 
 **Mudanças concluídas nesta sessão:**
-- `product/packages/orchestrator/src/service.js` atualizado para expor metadados dos squads criativos
-- `product/packages/runtime/src/service.js` atualizado para persistir outputs do fluxo criativo seeded
-- `product/packages/tools/src/runner.js` atualizado com bindings criativos mínimos
-- `product/tests/e2e/run.mjs` atualizado para cobrir o cenário criativo
-- `product/README.md` atualizado para documentar o primeiro corte criativo
+- `product/packages/shared/src/seeds.js` atualizado com o squad `creative-image`
+- `product/packages/tools/src/runner.js` atualizado para persistir composition plan, previews SVG e gallery HTML
+- `product/packages/runtime/src/service.js` atualizado para passar `artifacts_dir` aos tool bindings
+- `product/tests/e2e/run.mjs` atualizado para cobrir o fluxo renderizável de imagem
+- `product/README.md` e docs de `product/tests/e2e/` atualizados para refletir o novo corte
 - `npm --prefix product run check` executado com sucesso
 - `npm --prefix product run regression` executado com sucesso
-- `workboard/BACKLOG.md` atualizado com `TASK-040`
+- `workboard/BACKLOG.md` atualizado com `TASK-041`
 - `workboard/IN_PROGRESS.md` zerado
-- `workboard/DONE.md` atualizado para incluir `TASK-039`
-- `handoffs/ACTIVE.md` reconciliado para refletir o fechamento da TASK-039
+- `workboard/DONE.md` atualizado para incluir `TASK-040`
+- `handoffs/ACTIVE.md` reconciliado para refletir o fechamento da task
 
 ---
 
 ## Próxima Ação Recomendada
 
-1. Iniciar `TASK-040`
-2. Implementar `creative-image` como primeiro fluxo renderizável
+1. Iniciar `TASK-041`
+2. Implementar `creative-video` como primeiro fluxo vertical renderizável
 3. Manter staging-first antes de qualquer passo ligado ao servidor de produção
 
 **Papéis recomendados para a próxima sessão:** `Program Architect`, `Workflow Field Researcher`
@@ -59,7 +59,7 @@ NENHUM.
 
 ## Snapshot de Contexto
 
-`handoffs/snapshots/2026-04-24-codex-task-039-complete.md`
+`handoffs/snapshots/2026-04-24-codex-task-040-complete.md`
 
 ---
 
@@ -73,8 +73,8 @@ O repositório agora tem duas camadas ativas e coerentes:
 - o registry agora tem lifecycle formal e approvals explícitos
 
 **O que fazer a seguir:**
-- iniciar `TASK-040`
-- usar o corte seeded atual como base para renderização de `creative-image`
+- iniciar `TASK-041`
+- usar o corte de `creative-image` como base para o primeiro fluxo vertical de vídeo
 - seguir preservando o fluxo operacional atual da Doze e o guardrail de staging-first
 
 **Próximo agente recomendado:** `Program Architect` com apoio de `Workflow Field Researcher`

--- a/handoffs/snapshots/2026-04-24-codex-task-040-complete.md
+++ b/handoffs/snapshots/2026-04-24-codex-task-040-complete.md
@@ -1,0 +1,28 @@
+# Snapshot — TASK-040
+
+**Data:** 2026-04-24  
+**Agente:** codex  
+**Branch:** `task/24-creative-image-first-renderable`  
+**Issue:** `#24`
+
+## Objetivo
+
+Implementar `creative-image` como o primeiro fluxo criativo renderizável do `product/`, usando `paperclip-composer`, `ffmpeg-render` e o QA já seeded.
+
+## Entregas
+
+- seed de `creative-image` adicionado ao produto
+- `paperclip-composer` agora persiste `composition-plan.json` e frames SVG
+- `ffmpeg-render` agora persiste `preview-manifest.json`, previews SVG e `preview-gallery.html`
+- o runtime passa `artifacts_dir` para os bindings de tools
+- a regressão cobre `creative-image` com checkpoint, artifacts persistidos e arquivos verificáveis
+- a documentação de produto e E2E foi alinhada com o novo corte
+
+## Validação
+
+- `npm --prefix product run check`
+- `npm --prefix product run regression`
+
+## Próxima ação recomendada
+
+Iniciar `TASK-041` para implementar `creative-video` como o primeiro fluxo vertical renderizável, reaproveitando o padrão de artifacts e checkpoint validado em `creative-image`.

--- a/product/README.md
+++ b/product/README.md
@@ -62,14 +62,17 @@ O baseline do produto agora também inclui o primeiro corte da trilha criativa:
 - `creative-control`
 - `reference-lab`
 - `creative-qa`
+- `creative-image`
 
 Neste corte:
 - os squads já existem como seeds do produto
-- o fluxo básico `contexto -> referencia -> QA` já pode ser iniciado localmente
+- o fluxo `contexto -> referencia -> composicao/render -> QA` já pode ser iniciado localmente
+- `creative-image` persiste plano de assets, composicao declarativa, previews renderizaveis em SVG e gallery HTML de dry-run
 - o objetivo ainda é `local-dev` e `staging`
 - produção continua fora do caminho default
 
 O que ainda nao entra neste corte:
 - deploy no servidor de produção
 - publicação real por default
-- pipeline completa de imagem e vídeo final
+- pipeline completa de vídeo final
+- render final dependente de stack externa além do dry-run local/staging

--- a/product/packages/runtime/src/service.js
+++ b/product/packages/runtime/src/service.js
@@ -339,6 +339,7 @@ export class RuntimeService {
         squad_slug: run.squad_slug,
         workspace_slug: run.workspace_slug,
         step_id: step.id,
+        artifacts_dir: this.store.artifactsDir,
         request_context: run.request_context,
         machine_profile: run.machine_profile,
         environment_scope: run.environment_scope,
@@ -376,6 +377,7 @@ export class RuntimeService {
         squad_slug: run.squad_slug,
         workspace_slug: run.workspace_slug,
         step_id: step.id,
+        artifacts_dir: this.store.artifactsDir,
         request_context: run.request_context,
         machine_profile: run.machine_profile,
         environment_scope: run.environment_scope,
@@ -435,6 +437,7 @@ export class RuntimeService {
 
   buildContractSummary(step, contractName, run) {
     const contractLabelMap = {
+      "asset_plan.json": "Plano de assets consolidado",
       "creative_intent.json": "Intento criativo consolidado",
       "approval_packet.json": "Pacote de aprovacao preparado",
       "brand_context.json": "Contexto de marca consolidado",

--- a/product/packages/shared/src/seeds.js
+++ b/product/packages/shared/src/seeds.js
@@ -214,6 +214,59 @@ function createCreativeQaSteps() {
   ];
 }
 
+function createCreativeImageSteps() {
+  return [
+    {
+      id: "planejar-assets",
+      kind: "prompt",
+      executor: "inline",
+      label: "Planeja assets, formatos e densidade do criativo",
+      output_contracts: ["asset_plan.json"],
+      machine_profile: "cpu-safe",
+      environment_scope: "local-dev",
+      qa_gate: "brand",
+      risk_level: "low"
+    },
+    {
+      id: "compor-layout",
+      kind: "tool",
+      executor: "tool-runner",
+      label: "Compõe o layout declarativo da peça",
+      tool_slugs: ["paperclip-composer"],
+      input_contracts: ["asset_plan.json", "creative_intent.json", "reference_pack.json"],
+      machine_profile: "balanced",
+      environment_scope: "staging",
+      qa_gate: "brand",
+      risk_level: "medium"
+    },
+    {
+      id: "renderizar-previews",
+      kind: "tool",
+      executor: "tool-runner",
+      label: "Renderiza previews e pacote de entrega da peça",
+      tool_slugs: ["ffmpeg-render"],
+      input_contracts: ["asset_plan.json"],
+      machine_profile: "balanced",
+      environment_scope: "staging",
+      qa_gate: "delivery",
+      risk_level: "medium"
+    },
+    {
+      id: "aprovar-render",
+      kind: "checkpoint",
+      executor: "checkpoint",
+      label: "Aprovar render antes do QA final",
+      input_contracts: ["preview_manifest.json"],
+      requiresCheckpoint: true,
+      on_reject: "compor-layout",
+      machine_profile: "cpu-safe",
+      environment_scope: "staging",
+      qa_gate: "brand-and-delivery",
+      risk_level: "medium"
+    }
+  ];
+}
+
 export function createSeeds() {
   const capabilities = [
     {
@@ -481,6 +534,7 @@ export function createSeeds() {
   const creativeControlId = createId();
   const referenceLabId = createId();
   const creativeQaId = createId();
+  const creativeImageId = createId();
 
   const squads = [
     {
@@ -571,6 +625,27 @@ export function createSeeds() {
         .filter((capability) => ["brand-qa", "delivery-qa"].includes(capability.slug))
         .map((capability) => capability.id),
       steps: createCreativeQaSteps()
+    },
+    {
+      id: creativeImageId,
+      slug: "creative-image",
+      name: "Creative Image",
+      workspace_slug: "doze",
+      version: "1.0.0",
+      pipeline_id: createId(),
+      capability_ids: capabilities
+        .filter((capability) => ["paperclip-composer", "ffmpeg-render", "brand-qa", "delivery-qa"].includes(capability.slug))
+        .map((capability) => capability.id),
+      memory_scope: "run",
+      default_model_tier: "powerful",
+      system_family: "creative",
+      machine_profile: "balanced",
+      environment_scope: "staging",
+      context_precedence: ["operational-truth", "campaign-context", "brand-profile", "creative-playbook"],
+      qa_capability_ids: capabilities
+        .filter((capability) => ["brand-qa", "delivery-qa"].includes(capability.slug))
+        .map((capability) => capability.id),
+      steps: createCreativeImageSteps()
     }
   ];
 

--- a/product/packages/tools/src/runner.js
+++ b/product/packages/tools/src/runner.js
@@ -1,3 +1,84 @@
+import fs from "node:fs";
+import path from "node:path";
+
+function ensureDirectory(directoryPath) {
+  fs.mkdirSync(directoryPath, { recursive: true });
+}
+
+function getStepArtifactsDir(context) {
+  return path.join(context.artifacts_dir ?? process.cwd(), context.run_id ?? "global", context.step_id ?? "step");
+}
+
+function writeJsonArtifact(filePath, payload) {
+  ensureDirectory(path.dirname(filePath));
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+function writeTextArtifact(filePath, payload) {
+  ensureDirectory(path.dirname(filePath));
+  fs.writeFileSync(filePath, payload, "utf8");
+}
+
+function createSlideSvg({ title, subtitle, accent, slideIndex, slideCount, width, height }) {
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">`,
+    '  <defs>',
+    '    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">',
+    '      <stop offset="0%" stop-color="#090909" />',
+    '      <stop offset="100%" stop-color="#1a1a1a" />',
+    "    </linearGradient>",
+    '    <filter id="grain">',
+    '      <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="stitch" />',
+    '      <feColorMatrix type="saturate" values="0" />',
+    '      <feComponentTransfer><feFuncA type="table" tableValues="0 0.05" /></feComponentTransfer>',
+    "    </filter>",
+    "  </defs>",
+    '  <rect width="100%" height="100%" fill="url(#bg)" />',
+    `  <rect x="64" y="64" width="${width - 128}" height="${height - 128}" rx="28" fill="none" stroke="${accent}" stroke-width="8" />`,
+    `  <circle cx="${width - 120}" cy="120" r="36" fill="${accent}" opacity="0.9" />`,
+    `  <text x="96" y="180" fill="#f8f8f8" font-family="Arial, Helvetica, sans-serif" font-size="112" font-weight="700">${title}</text>`,
+    `  <text x="96" y="300" fill="#d7d7d7" font-family="Arial, Helvetica, sans-serif" font-size="42">${subtitle}</text>`,
+    `  <text x="96" y="${height - 116}" fill="${accent}" font-family="Arial, Helvetica, sans-serif" font-size="36" font-weight="700">SLIDE ${slideIndex} / ${slideCount}</text>`,
+    '  <rect width="100%" height="100%" fill="#ffffff" opacity="0.08" filter="url(#grain)" />',
+    "</svg>"
+  ].join("\n");
+}
+
+function createStaticHtmlPreview({ title, subtitle, previewFiles }) {
+  const cards = previewFiles
+    .map(
+      (previewFile, index) => `
+      <article>
+        <h2>Preview ${index + 1}</h2>
+        <img src="${path.basename(previewFile)}" alt="Preview ${index + 1}" />
+      </article>`
+    )
+    .join("\n");
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>${title}</title>
+    <style>
+      body { background: #111; color: #f5f5f5; font-family: Arial, Helvetica, sans-serif; margin: 0; padding: 24px; }
+      header { margin-bottom: 24px; }
+      main { display: grid; gap: 24px; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
+      article { background: #1a1a1a; border: 1px solid #333; border-radius: 16px; padding: 16px; }
+      img { width: 100%; height: auto; border-radius: 12px; display: block; background: #000; }
+      p { color: #cfcfcf; max-width: 70ch; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>${title}</h1>
+      <p>${subtitle}</p>
+    </header>
+    <main>${cards}</main>
+  </body>
+</html>`;
+}
+
 function buildGa4Artifact(context) {
   return {
     tool: "ga4",
@@ -178,25 +259,134 @@ function buildDeliveryQaArtifact(context) {
 }
 
 function buildPaperclipComposerArtifact(context) {
+  const stepArtifactsDir = getStepArtifactsDir(context);
+  const outputFormat = context.request_context?.output_format ?? "static-post";
+  const slideCount = Math.max(1, Number(context.request_context?.frame_count ?? (outputFormat === "carousel" ? 3 : 1)));
+  const width = outputFormat === "stories" ? 1080 : 1080;
+  const height = outputFormat === "stories" ? 1920 : 1350;
+  const accent = context.request_context?.accent_color ?? "#ff4d4f";
+  const campaignName = context.request_context?.campaign_slug ?? "creative-baseline";
+  const brandName = context.request_context?.brand_slug ?? "doze-crew";
+  const framesDir = path.join(stepArtifactsDir, "composition");
+  const framePaths = [];
+
+  ensureDirectory(framesDir);
+
+  for (let index = 1; index <= slideCount; index += 1) {
+    const framePath = path.join(framesDir, `frame-${String(index).padStart(2, "0")}.svg`);
+    const frameSvg = createSlideSvg({
+      title: brandName.toUpperCase(),
+      subtitle: `${campaignName} • ${outputFormat} • ${context.intent_kind ?? "creative-image"}`,
+      accent,
+      slideIndex: index,
+      slideCount,
+      width,
+      height
+    });
+
+    writeTextArtifact(framePath, frameSvg);
+    framePaths.push(framePath);
+  }
+
+  const compositionPath = path.join(stepArtifactsDir, "composition-plan.json");
+  const composition = {
+    tool: "paperclip-composer",
+    output_format: outputFormat,
+    machine_profile: context.machine_profile ?? "balanced",
+    environment_scope: context.environment_scope ?? "staging",
+    canvas: {
+      width,
+      height
+    },
+    frames: framePaths.map((framePath, index) => ({
+      index: index + 1,
+      path: framePath
+    }))
+  };
+
+  writeJsonArtifact(compositionPath, composition);
+
   return {
     tool: "paperclip-composer",
     artifact_type: "composition_plan",
     summary: `Composicao declarativa preparada para ${context.squad_slug}`,
     details: {
       workspace: context.workspace_slug,
-      machine_profile: context.machine_profile ?? "balanced"
+      machine_profile: context.machine_profile ?? "balanced",
+      output_format: outputFormat,
+      frame_count: slideCount,
+      composition_path: compositionPath,
+      frame_paths: framePaths
     }
   };
 }
 
 function buildFfmpegRenderArtifact(context) {
+  const stepArtifactsDir = getStepArtifactsDir(context);
+  const renderDir = path.join(stepArtifactsDir, "render");
+  const previewManifestPath = path.join(stepArtifactsDir, "preview-manifest.json");
+  const galleryPath = path.join(stepArtifactsDir, "preview-gallery.html");
+  const compositionDir = path.join(context.artifacts_dir ?? process.cwd(), context.run_id ?? "global", "compor-layout", "composition");
+  const previewFiles = [];
+  const outputFormat = context.request_context?.output_format ?? "static-post";
+  const requestedFrames = Math.max(1, Number(context.request_context?.frame_count ?? (outputFormat === "carousel" ? 3 : 1)));
+
+  ensureDirectory(renderDir);
+
+  for (let index = 1; index <= requestedFrames; index += 1) {
+    const sourcePath = path.join(compositionDir, `frame-${String(index).padStart(2, "0")}.svg`);
+    const targetPath = path.join(renderDir, `preview-${String(index).padStart(2, "0")}.svg`);
+
+    if (fs.existsSync(sourcePath)) {
+      fs.copyFileSync(sourcePath, targetPath);
+    } else {
+      const fallbackSvg = createSlideSvg({
+        title: (context.request_context?.brand_slug ?? "doze-crew").toUpperCase(),
+        subtitle: `${context.request_context?.campaign_slug ?? "creative-baseline"} • preview fallback`,
+        accent: context.request_context?.accent_color ?? "#ff4d4f",
+        slideIndex: index,
+        slideCount: requestedFrames,
+        width: 1080,
+        height: outputFormat === "stories" ? 1920 : 1350
+      });
+      writeTextArtifact(targetPath, fallbackSvg);
+    }
+
+    previewFiles.push(targetPath);
+  }
+
+  const galleryHtml = createStaticHtmlPreview({
+    title: `${context.squad_slug} preview gallery`,
+    subtitle: `Render dry-run para ${context.request_context?.campaign_slug ?? "creative-baseline"}`,
+    previewFiles
+  });
+
+  writeTextArtifact(galleryPath, galleryHtml);
+
+  const manifest = {
+    tool: "ffmpeg-render",
+    output_format: outputFormat,
+    environment_scope: context.environment_scope ?? "staging",
+    previews: previewFiles.map((filePath, index) => ({
+      index: index + 1,
+      path: filePath
+    })),
+    gallery_path: galleryPath
+  };
+
+  writeJsonArtifact(previewManifestPath, manifest);
+
   return {
     tool: "ffmpeg-render",
     artifact_type: "preview_manifest",
     summary: `Manifesto de previews preparado para ${context.squad_slug}`,
     details: {
       workspace: context.workspace_slug,
-      environment_scope: context.environment_scope ?? "staging"
+      environment_scope: context.environment_scope ?? "staging",
+      output_format: outputFormat,
+      preview_manifest_path: previewManifestPath,
+      preview_files: previewFiles,
+      gallery_path: galleryPath
     }
   };
 }

--- a/product/tests/e2e/README-RUNBOOK.md
+++ b/product/tests/e2e/README-RUNBOOK.md
@@ -10,9 +10,10 @@
 1. seed capability and run fixtures
 2. execute marketing scenario
 3. execute intelligence scenario
-4. approve and reject checkpoints
-5. promote and rollback capability
-6. restart services and verify recovery
+4. execute creative image scenario and approve render gate
+5. approve and reject checkpoints
+6. promote and rollback capability
+7. restart services and verify recovery
 
 ## Verification points
 
@@ -21,6 +22,7 @@
 - promotion status
 - audit trail
 - output availability
+- persisted preview files and manifest availability
 
 ## Stop conditions
 

--- a/product/tests/e2e/README.md
+++ b/product/tests/e2e/README.md
@@ -13,6 +13,7 @@
 5. validar persistência de memória, outputs e histórico
 6. validar restart safety para runs aguardando checkpoint
 7. validar rollback de capability com trilha auditável
+8. validar o primeiro fluxo renderizável de `creative-image` com artifacts persistidos
 
 ## Scenario matrix
 
@@ -25,6 +26,7 @@
 | Promotion to staging | promover capability | status muda para `staging` com aprovação registrada | staging only |
 | Rollback | desfazer uma promoção | status volta ao estado anterior com evento auditado | staging only |
 | Restart recovery | reiniciar API/worker | run retoma do último estado seguro | staging only |
+| Creative image render | renderizar a primeira peça estática/carrossel | `asset_plan`, `composition_plan`, `preview_manifest` e previews persistidos | staging only |
 
 ## Acceptance criteria
 
@@ -32,6 +34,7 @@
 - toda promoção e rollback precisa gerar rastreio
 - checkpoints rejeitados precisam levar o run para o passo correto
 - os outputs precisam permanecer consultáveis após restart
+- o fluxo `creative-image` precisa persistir arquivos renderizáveis consultáveis no storage local
 - qualquer validação em produção continua proibida até o gate staging ficar verde
 - o comando `npm --prefix product run regression` executa a suíte completa sem passos manuais intermediários
 

--- a/product/tests/e2e/SCENARIO_MATRIX.md
+++ b/product/tests/e2e/SCENARIO_MATRIX.md
@@ -13,9 +13,11 @@
 | E2E-04 | Promotion approval | capability promotion pending | approve promotion | capability transitions to target status |
 | E2E-05 | Rollback approval | rollback pending | approve rollback | capability transitions back and audit is stored |
 | E2E-06 | Restart recovery | run waiting_checkpoint | restart services | run state restored without losing checkpoint |
+| E2E-07 | Creative image render | `creative-image` at least `staging` | start run, render previews, approve render gate | preview artifacts and manifest persistidos |
 
 ## Notes
 
 - all scenarios are staging-first
 - production validation is explicitly out of scope here
 - write-capable integrations require explicit approval path
+- `creative-image` is validated with dry-run artifacts only; no production publishing is involved

--- a/product/tests/e2e/run.mjs
+++ b/product/tests/e2e/run.mjs
@@ -275,6 +275,10 @@ async function runCreativeScenario() {
     squads.items.some((item) => item.slug === "creative-qa"),
     "Creative QA squad should be listed by the API"
   );
+  assert(
+    squads.items.some((item) => item.slug === "creative-image"),
+    "Creative image squad should be listed by the API"
+  );
 
   const referenceRun = await requestJson("/v1/runs", {
     method: "POST",
@@ -345,6 +349,62 @@ async function runCreativeScenario() {
     "Creative control should produce approval packet"
   );
 
+  const imageRun = await requestJson("/v1/runs", {
+    method: "POST",
+    body: JSON.stringify({
+      squad_slug: "creative-image",
+      workspace_slug: "doze",
+      requested_by: "e2e",
+      intent_kind: "creative-image",
+      machine_profile: "balanced",
+      environment_scope: "staging",
+      request_context: {
+        brand_slug: "doze-crew",
+        campaign_slug: "spring-drop",
+        channel: "instagram",
+        style_direction: "modern-underground",
+        output_format: "carousel",
+        frame_count: 3,
+        accent_color: "#ff4d4f"
+      }
+    })
+  });
+
+  const completedImage = await driveCheckpointedRun(imageRun.id, { expectedCheckpoints: 1 });
+  assert(completedImage.status === "succeeded", "Creative image run did not finish successfully");
+
+  const imageOutputs = await requestJson(`/v1/runs/${imageRun.id}/outputs`);
+  assert(
+    imageOutputs.items.some((item) => item.artifact_type === "asset_plan"),
+    "Creative image should produce an asset plan"
+  );
+  assert(
+    imageOutputs.items.some((item) => item.artifact_type === "composition_plan"),
+    "Creative image should produce a composition plan"
+  );
+  assert(
+    imageOutputs.items.some((item) => item.artifact_type === "preview_manifest"),
+    "Creative image should produce a preview manifest"
+  );
+
+  const imageArtifacts = await requestJson(`/v1/runs/${imageRun.id}/artifacts`);
+  const compositionArtifact = imageArtifacts.items.find((item) => item.artifact_type === "composition_plan");
+  const previewArtifact = imageArtifacts.items.find((item) => item.artifact_type === "preview_manifest");
+
+  assert(compositionArtifact, "Creative image should persist a composition artifact");
+  assert(previewArtifact, "Creative image should persist a preview artifact");
+  assert(existsSync(compositionArtifact.details.composition_path), "Composition plan file should exist");
+  assert(
+    compositionArtifact.details.frame_paths.every((framePath) => existsSync(framePath)),
+    "Composition frame files should exist"
+  );
+  assert(existsSync(previewArtifact.details.preview_manifest_path), "Preview manifest file should exist");
+  assert(
+    previewArtifact.details.preview_files.every((previewPath) => existsSync(previewPath)),
+    "Rendered preview files should exist"
+  );
+  assert(existsSync(previewArtifact.details.gallery_path), "Preview gallery file should exist");
+
   const qaRun = await requestJson("/v1/runs", {
     method: "POST",
     body: JSON.stringify({
@@ -376,6 +436,7 @@ async function runCreativeScenario() {
   return {
     referenceRunId: referenceRun.id,
     controlRunId: controlRun.id,
+    imageRunId: imageRun.id,
     qaRunId: qaRun.id
   };
 }

--- a/workboard/BACKLOG.md
+++ b/workboard/BACKLOG.md
@@ -14,17 +14,17 @@
 
 ### P1 — Alta Prioridade
 
-### TASK-040 | Implementar `creative-image` como primeiro fluxo criativo renderizável
+### TASK-041 | Implementar `creative-video` como primeiro fluxo vertical renderizável
 - **Tipo:** research
 - **Prioridade:** P1
-- **Tamanho:** M
+- **Tamanho:** L
 - **Status:** `backlog`
-- **Objetivo:** estender o corte criativo atual para executar o primeiro fluxo renderizável de imagem estática/carrossel com `paperclip-composer`, `ffmpeg-render` e QA já seeded.
-- **Dependências:** TASK-039 concluída
+- **Objetivo:** estender a trilha criativa para o primeiro fluxo vertical curto com planejamento de frames, composição, render de previews e QA orientado a identidade e retenção.
+- **Dependências:** TASK-040 concluída
 - **Output esperado:**
-  - fluxo `creative-image` implementado no `product/`
-  - artifacts e previews renderizáveis persistidos
-  - regressão cobrindo o fluxo de imagem
-  - documentação local/staging do primeiro fluxo renderizável
+  - fluxo `creative-video` implementado no `product/`
+  - artifacts persistidos de shot plan, edit plan e previews verticais
+  - regressão cobrindo o fluxo de vídeo curto
+  - documentação local/staging do primeiro fluxo vertical renderizável
 
 ## Backlog do Squad 1 (a ser preenchido pelo Squad 0 via TASK-015)

--- a/workboard/DONE.md
+++ b/workboard/DONE.md
@@ -21,6 +21,27 @@
 
 ## Histórico
 
+### TASK-040 | Implementar `creative-image` como primeiro fluxo criativo renderizável
+- **Concluída em:** 2026-04-24
+- **Por:** codex
+- **Issue:** #24 (fechada)
+- **Branch:** task/24-creative-image-first-renderable
+- **Output produzido:**
+  - `product/packages/shared/src/seeds.js`
+  - `product/packages/tools/src/runner.js`
+  - `product/packages/runtime/src/service.js`
+  - `product/tests/e2e/run.mjs`
+  - `product/README.md`
+  - `product/tests/e2e/README.md`
+  - `product/tests/e2e/SCENARIO_MATRIX.md`
+  - `product/tests/e2e/README-RUNBOOK.md`
+  - `workboard/BACKLOG.md`
+  - `workboard/IN_PROGRESS.md`
+  - `workboard/DONE.md`
+  - `handoffs/ACTIVE.md`
+  - `handoffs/snapshots/2026-04-24-codex-task-040-complete.md`
+- **Notas:** O produto agora executa `creative-image` como primeiro fluxo renderizável de imagem, persistindo `asset_plan`, `composition_plan`, previews SVG e gallery HTML de dry-run validados pela regressão canônica.
+
 ### TASK-039 | Implementar o primeiro corte do sistema criativo em `product/`
 - **Concluída em:** 2026-04-24
 - **Por:** codex


### PR DESCRIPTION
## Summary
- adiciona o squad `creative-image` como primeiro fluxo renderizável de imagem
- persiste `asset_plan`, `composition_plan`, previews SVG e gallery HTML de dry-run
- expande a regressão e a documentação local/staging para o novo corte criativo

## Testing
- npm --prefix product run check
- npm --prefix product run regression

Closes #24