### PR TITLE
TASK-041: implementar creative-video como primeiro fluxo vertical renderizável

### DIFF
--- a/handoffs/ACTIVE.md
+++ b/handoffs/ACTIVE.md
@@ -8,7 +8,7 @@
 ## Estado do Bastão
 
 - **baton:** UNASSIGNED
-- **last-updated-by:** codex (task 040 completed)
+- **last-updated-by:** codex (task 041 completed)
 - **last-updated-at:** 2026-04-24
 - **last-read-by:** codex
 - **last-read-at:** 2026-04-24
@@ -17,34 +17,35 @@
 
 ## Tasks em Voo
 
-1. TASK-040 concluída com o primeiro fluxo renderizável de imagem em `product/`.
-2. Próximo passo: iniciar `TASK-041` no backlog.
+1. TASK-041 concluída com o primeiro fluxo vertical renderizável em `product/`.
+2. Próximo passo: iniciar `TASK-042` no backlog.
 
 ---
 
 ## Última Ação Completada
 
-Fechamento da TASK-040 com `creative-image` implementado e regressão verde.
+Fechamento da TASK-041 com `creative-video` implementado e regressão verde.
 
 **Mudanças concluídas nesta sessão:**
-- `product/packages/shared/src/seeds.js` atualizado com o squad `creative-image`
-- `product/packages/tools/src/runner.js` atualizado para persistir composition plan, previews SVG e gallery HTML
-- `product/packages/runtime/src/service.js` atualizado para passar `artifacts_dir` aos tool bindings
-- `product/tests/e2e/run.mjs` atualizado para cobrir o fluxo renderizável de imagem
+- `product/packages/shared/src/seeds.js` atualizado com o squad `creative-video` e capabilities de video
+- `product/packages/skills/src/catalog.js` atualizado com `frame-planner`, `motion-editor` e `vfx-finisher`
+- `product/packages/tools/src/runner.js` atualizado para persistir storyboard vertical, previews SVG e playlist de dry-run
+- `product/packages/runtime/src/service.js` atualizado com summaries dos contracts de video
+- `product/tests/e2e/run.mjs` atualizado para cobrir o fluxo renderizável de video
 - `product/README.md` e docs de `product/tests/e2e/` atualizados para refletir o novo corte
 - `npm --prefix product run check` executado com sucesso
 - `npm --prefix product run regression` executado com sucesso
-- `workboard/BACKLOG.md` atualizado com `TASK-041`
+- `workboard/BACKLOG.md` atualizado com `TASK-042`
 - `workboard/IN_PROGRESS.md` zerado
-- `workboard/DONE.md` atualizado para incluir `TASK-040`
+- `workboard/DONE.md` atualizado para incluir `TASK-041`
 - `handoffs/ACTIVE.md` reconciliado para refletir o fechamento da task
 
 ---
 
 ## Próxima Ação Recomendada
 
-1. Iniciar `TASK-041`
-2. Implementar `creative-video` como primeiro fluxo vertical renderizável
+1. Iniciar `TASK-042`
+2. Implementar `publishing-control` como empacotamento dry-run do fluxo criativo
 3. Manter staging-first antes de qualquer passo ligado ao servidor de produção
 
 **Papéis recomendados para a próxima sessão:** `Program Architect`, `Workflow Field Researcher`
@@ -59,7 +60,7 @@ NENHUM.
 
 ## Snapshot de Contexto
 
-`handoffs/snapshots/2026-04-24-codex-task-040-complete.md`
+`handoffs/snapshots/2026-04-24-codex-task-041-complete.md`
 
 ---
 
@@ -73,8 +74,8 @@ O repositório agora tem duas camadas ativas e coerentes:
 - o registry agora tem lifecycle formal e approvals explícitos
 
 **O que fazer a seguir:**
-- iniciar `TASK-041`
-- usar o corte de `creative-image` como base para o primeiro fluxo vertical de vídeo
+- iniciar `TASK-042`
+- conectar `creative-image` e `creative-video` ao primeiro handoff de publicação dry-run
 - seguir preservando o fluxo operacional atual da Doze e o guardrail de staging-first
 
 **Próximo agente recomendado:** `Program Architect` com apoio de `Workflow Field Researcher`

--- a/handoffs/snapshots/2026-04-24-codex-task-041-complete.md
+++ b/handoffs/snapshots/2026-04-24-codex-task-041-complete.md
@@ -1,0 +1,28 @@
+# Snapshot — TASK-041
+
+**Data:** 2026-04-24  
+**Agente:** codex  
+**Branch:** `task/26-creative-video-first-renderable`  
+**Issue:** `#26`
+
+## Objetivo
+
+Implementar `creative-video` como o primeiro fluxo vertical renderizável do `product/`, usando `paperclip-composer`, `ffmpeg-render` e o QA já seeded.
+
+## Entregas
+
+- seed de `creative-video` adicionado ao produto
+- capabilities iniciais de `frame-planner`, `motion-editor` e `vfx-finisher`
+- `paperclip-composer` agora persiste storyboard vertical em SVG
+- `ffmpeg-render` agora persiste `preview-manifest.json`, previews SVG, `preview-gallery.html` e `preview-playlist.json`
+- a regressão cobre `creative-video` com checkpoint, contracts persistidos e arquivos verificáveis
+- a documentação de produto e E2E foi alinhada com o novo corte
+
+## Validação
+
+- `npm --prefix product run check`
+- `npm --prefix product run regression`
+
+## Próxima ação recomendada
+
+Iniciar `TASK-042` para implementar `publishing-control` como o primeiro handoff de empacotamento dry-run do fluxo criativo, sem publicação real por default.

--- a/product/README.md
+++ b/product/README.md
@@ -63,16 +63,18 @@ O baseline do produto agora também inclui o primeiro corte da trilha criativa:
 - `reference-lab`
 - `creative-qa`
 - `creative-image`
+- `creative-video`
 
 Neste corte:
 - os squads já existem como seeds do produto
-- o fluxo `contexto -> referencia -> composicao/render -> QA` já pode ser iniciado localmente
+- o fluxo `contexto -> referencia -> composicao/render -> QA` já pode ser iniciado localmente para imagem e video curto
 - `creative-image` persiste plano de assets, composicao declarativa, previews renderizaveis em SVG e gallery HTML de dry-run
+- `creative-video` persiste `shot_plan`, `vfx_plan`, `edit_decision_list`, storyboard vertical, previews SVG e playlist de dry-run
 - o objetivo ainda é `local-dev` e `staging`
 - produção continua fora do caminho default
 
 O que ainda nao entra neste corte:
 - deploy no servidor de produção
 - publicação real por default
-- pipeline completa de vídeo final
 - render final dependente de stack externa além do dry-run local/staging
+- integrações multimodais pesadas fora do perfil local/staging

--- a/product/packages/runtime/src/service.js
+++ b/product/packages/runtime/src/service.js
@@ -438,6 +438,9 @@ export class RuntimeService {
   buildContractSummary(step, contractName, run) {
     const contractLabelMap = {
       "asset_plan.json": "Plano de assets consolidado",
+      "shot_plan.json": "Plano de shots consolidado",
+      "edit_decision_list.json": "Edit decision list consolidado",
+      "vfx_plan.json": "Plano de VFX consolidado",
       "creative_intent.json": "Intento criativo consolidado",
       "approval_packet.json": "Pacote de aprovacao preparado",
       "brand_context.json": "Contexto de marca consolidado",

--- a/product/packages/shared/src/seeds.js
+++ b/product/packages/shared/src/seeds.js
@@ -267,6 +267,70 @@ function createCreativeImageSteps() {
   ];
 }
 
+function createCreativeVideoSteps() {
+  return [
+    {
+      id: "planejar-frames",
+      kind: "prompt",
+      executor: "inline",
+      label: "Planeja beats, shots e linguagem de VFX do video",
+      output_contracts: ["shot_plan.json", "vfx_plan.json"],
+      machine_profile: "balanced",
+      environment_scope: "local-dev",
+      qa_gate: "brand",
+      risk_level: "medium"
+    },
+    {
+      id: "compor-storyboard",
+      kind: "tool",
+      executor: "tool-runner",
+      label: "Compõe storyboard vertical e quadros-guia do video",
+      tool_slugs: ["paperclip-composer"],
+      input_contracts: ["shot_plan.json", "vfx_plan.json", "creative_intent.json", "reference_pack.json"],
+      machine_profile: "balanced",
+      environment_scope: "staging",
+      qa_gate: "brand",
+      risk_level: "medium"
+    },
+    {
+      id: "montar-edl",
+      kind: "prompt",
+      executor: "inline",
+      label: "Monta o edit decision list do video curto",
+      output_contracts: ["edit_decision_list.json"],
+      machine_profile: "balanced",
+      environment_scope: "staging",
+      qa_gate: "delivery",
+      risk_level: "medium"
+    },
+    {
+      id: "renderizar-video",
+      kind: "tool",
+      executor: "tool-runner",
+      label: "Renderiza previews verticais e pacote de entrega do video",
+      tool_slugs: ["ffmpeg-render"],
+      input_contracts: ["shot_plan.json", "edit_decision_list.json", "vfx_plan.json"],
+      machine_profile: "balanced",
+      environment_scope: "staging",
+      qa_gate: "delivery",
+      risk_level: "medium"
+    },
+    {
+      id: "aprovar-previas-video",
+      kind: "checkpoint",
+      executor: "checkpoint",
+      label: "Aprovar previews do video antes do QA final",
+      input_contracts: ["preview_manifest.json"],
+      requiresCheckpoint: true,
+      on_reject: "compor-storyboard",
+      machine_profile: "cpu-safe",
+      environment_scope: "staging",
+      qa_gate: "brand-and-delivery",
+      risk_level: "high"
+    }
+  ];
+}
+
 export function createSeeds() {
   const capabilities = [
     {
@@ -440,6 +504,60 @@ export function createSeeds() {
     {
       id: createId(),
       kind: "skill",
+      slug: "frame-planner",
+      name: "Frame Planner",
+      workspace_slug: "doze",
+      status: "draft",
+      version: "1.0.0",
+      risk_level: "medium",
+      allowed_tools: ["frame-planner"],
+      summary: "Quebra o video em beats, shots e ritmos aprovaveis",
+      system_family: "creative",
+      machine_profile: "balanced",
+      environment_scope: "local-dev",
+      supports_dry_run: true,
+      requires_checkpoint: false,
+      artifact_contracts: ["shot_plan.json"]
+    },
+    {
+      id: createId(),
+      kind: "skill",
+      slug: "motion-editor",
+      name: "Motion Editor",
+      workspace_slug: "doze",
+      status: "draft",
+      version: "1.0.0",
+      risk_level: "medium",
+      allowed_tools: ["motion-editor"],
+      summary: "Traduz shots em ritmo, cortes e decisoes de montagem",
+      system_family: "creative",
+      machine_profile: "balanced",
+      environment_scope: "staging",
+      supports_dry_run: true,
+      requires_checkpoint: false,
+      artifact_contracts: ["edit_decision_list.json"]
+    },
+    {
+      id: createId(),
+      kind: "skill",
+      slug: "vfx-finisher",
+      name: "VFX Finisher",
+      workspace_slug: "doze",
+      status: "draft",
+      version: "1.0.0",
+      risk_level: "medium",
+      allowed_tools: ["vfx-finisher"],
+      summary: "Define overlays, textura, tipografia e linguagem de VFX",
+      system_family: "creative",
+      machine_profile: "balanced",
+      environment_scope: "staging",
+      supports_dry_run: true,
+      requires_checkpoint: false,
+      artifact_contracts: ["vfx_plan.json"]
+    },
+    {
+      id: createId(),
+      kind: "skill",
       slug: "brand-qa",
       name: "Brand QA",
       workspace_slug: "doze",
@@ -535,6 +653,7 @@ export function createSeeds() {
   const referenceLabId = createId();
   const creativeQaId = createId();
   const creativeImageId = createId();
+  const creativeVideoId = createId();
 
   const squads = [
     {
@@ -646,6 +765,37 @@ export function createSeeds() {
         .filter((capability) => ["brand-qa", "delivery-qa"].includes(capability.slug))
         .map((capability) => capability.id),
       steps: createCreativeImageSteps()
+    },
+    {
+      id: creativeVideoId,
+      slug: "creative-video",
+      name: "Creative Video",
+      workspace_slug: "doze",
+      version: "1.0.0",
+      pipeline_id: createId(),
+      capability_ids: capabilities
+        .filter((capability) =>
+          [
+            "frame-planner",
+            "motion-editor",
+            "vfx-finisher",
+            "paperclip-composer",
+            "ffmpeg-render",
+            "brand-qa",
+            "delivery-qa"
+          ].includes(capability.slug)
+        )
+        .map((capability) => capability.id),
+      memory_scope: "run",
+      default_model_tier: "powerful",
+      system_family: "creative",
+      machine_profile: "balanced",
+      environment_scope: "staging",
+      context_precedence: ["operational-truth", "campaign-context", "brand-profile", "creative-playbook"],
+      qa_capability_ids: capabilities
+        .filter((capability) => ["brand-qa", "delivery-qa"].includes(capability.slug))
+        .map((capability) => capability.id),
+      steps: createCreativeVideoSteps()
     }
   ];
 

--- a/product/packages/skills/src/catalog.js
+++ b/product/packages/skills/src/catalog.js
@@ -20,6 +20,21 @@ export const skillCatalog = [
     description: "Gera a intenção criativa e o treatment da peça"
   },
   {
+    slug: "frame-planner",
+    mode: "inline",
+    description: "Quebra o vídeo em beats, shots e ritmo aprováveis"
+  },
+  {
+    slug: "motion-editor",
+    mode: "inline",
+    description: "Traduz storyboard em cortes, ritmo e decisão de montagem"
+  },
+  {
+    slug: "vfx-finisher",
+    mode: "inline",
+    description: "Define textura, overlays, tipografia e linguagem de VFX"
+  },
+  {
     slug: "brand-qa",
     mode: "inline",
     description: "Valida aderência da peça à identidade da empresa"

--- a/product/packages/tools/src/runner.js
+++ b/product/packages/tools/src/runner.js
@@ -44,6 +44,32 @@ function createSlideSvg({ title, subtitle, accent, slideIndex, slideCount, width
   ].join("\n");
 }
 
+function createStoryboardSvg({ title, subtitle, accent, beatLabel, index, count, width, height }) {
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">`,
+    '  <defs>',
+    '    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">',
+    '      <stop offset="0%" stop-color="#050505" />',
+    '      <stop offset="100%" stop-color="#181818" />',
+    "    </linearGradient>",
+    '    <filter id="grain">',
+    '      <feTurbulence type="fractalNoise" baseFrequency="0.75" numOctaves="2" stitchTiles="stitch" />',
+    '      <feColorMatrix type="saturate" values="0" />',
+    '      <feComponentTransfer><feFuncA type="table" tableValues="0 0.08" /></feComponentTransfer>',
+    "    </filter>",
+    "  </defs>",
+    '  <rect width="100%" height="100%" fill="url(#bg)" />',
+    `  <rect x="72" y="72" width="${width - 144}" height="${height - 144}" rx="44" fill="none" stroke="${accent}" stroke-width="10" />`,
+    `  <text x="96" y="180" fill="${accent}" font-family="Arial, Helvetica, sans-serif" font-size="40" font-weight="700">VERTICAL CUT ${index} / ${count}</text>`,
+    `  <text x="96" y="310" fill="#f6f6f6" font-family="Arial, Helvetica, sans-serif" font-size="96" font-weight="700">${title}</text>`,
+    `  <text x="96" y="410" fill="#d6d6d6" font-family="Arial, Helvetica, sans-serif" font-size="42">${subtitle}</text>`,
+    `  <text x="96" y="${height - 220}" fill="#ffffff" font-family="Arial, Helvetica, sans-serif" font-size="64" font-weight="700">${beatLabel}</text>`,
+    `  <line x1="96" y1="${height - 170}" x2="${width - 96}" y2="${height - 170}" stroke="${accent}" stroke-width="8" />`,
+    '  <rect width="100%" height="100%" fill="#ffffff" opacity="0.07" filter="url(#grain)" />',
+    "</svg>"
+  ].join("\n");
+}
+
 function createStaticHtmlPreview({ title, subtitle, previewFiles }) {
   const cards = previewFiles
     .map(
@@ -77,6 +103,52 @@ function createStaticHtmlPreview({ title, subtitle, previewFiles }) {
     <main>${cards}</main>
   </body>
 </html>`;
+}
+
+function resolveOutputFormat(context) {
+  if (context.request_context?.output_format) {
+    return context.request_context.output_format;
+  }
+
+  if (context.intent_kind === "creative-video") {
+    return "vertical-video";
+  }
+
+  return "static-post";
+}
+
+function resolveFrameCount(outputFormat, requestedFrameCount) {
+  if (requestedFrameCount) {
+    return Math.max(1, Number(requestedFrameCount));
+  }
+
+  if (outputFormat === "carousel") {
+    return 3;
+  }
+
+  if (outputFormat === "vertical-video") {
+    return 6;
+  }
+
+  return 1;
+}
+
+function resolveCanvas(outputFormat) {
+  if (outputFormat === "stories" || outputFormat === "vertical-video") {
+    return { width: 1080, height: 1920 };
+  }
+
+  return { width: 1080, height: 1350 };
+}
+
+function resolveCompositionDir(context) {
+  const runRoot = path.join(context.artifacts_dir ?? process.cwd(), context.run_id ?? "global");
+  const candidates = [
+    path.join(runRoot, "compor-layout", "composition"),
+    path.join(runRoot, "compor-storyboard", "composition")
+  ];
+
+  return candidates.find((candidate) => fs.existsSync(candidate)) ?? candidates[0];
 }
 
 function buildGa4Artifact(context) {
@@ -260,10 +332,9 @@ function buildDeliveryQaArtifact(context) {
 
 function buildPaperclipComposerArtifact(context) {
   const stepArtifactsDir = getStepArtifactsDir(context);
-  const outputFormat = context.request_context?.output_format ?? "static-post";
-  const slideCount = Math.max(1, Number(context.request_context?.frame_count ?? (outputFormat === "carousel" ? 3 : 1)));
-  const width = outputFormat === "stories" ? 1080 : 1080;
-  const height = outputFormat === "stories" ? 1920 : 1350;
+  const outputFormat = resolveOutputFormat(context);
+  const slideCount = resolveFrameCount(outputFormat, context.request_context?.frame_count);
+  const { width, height } = resolveCanvas(outputFormat);
   const accent = context.request_context?.accent_color ?? "#ff4d4f";
   const campaignName = context.request_context?.campaign_slug ?? "creative-baseline";
   const brandName = context.request_context?.brand_slug ?? "doze-crew";
@@ -274,15 +345,27 @@ function buildPaperclipComposerArtifact(context) {
 
   for (let index = 1; index <= slideCount; index += 1) {
     const framePath = path.join(framesDir, `frame-${String(index).padStart(2, "0")}.svg`);
-    const frameSvg = createSlideSvg({
-      title: brandName.toUpperCase(),
-      subtitle: `${campaignName} • ${outputFormat} • ${context.intent_kind ?? "creative-image"}`,
-      accent,
-      slideIndex: index,
-      slideCount,
-      width,
-      height
-    });
+    const frameSvg =
+      outputFormat === "vertical-video"
+        ? createStoryboardSvg({
+            title: brandName.toUpperCase(),
+            subtitle: `${campaignName} • ${context.intent_kind ?? "creative-video"}`,
+            accent,
+            beatLabel: `Beat ${index}`,
+            index,
+            count: slideCount,
+            width,
+            height
+          })
+        : createSlideSvg({
+            title: brandName.toUpperCase(),
+            subtitle: `${campaignName} • ${outputFormat} • ${context.intent_kind ?? "creative-image"}`,
+            accent,
+            slideIndex: index,
+            slideCount,
+            width,
+            height
+          });
 
     writeTextArtifact(framePath, frameSvg);
     framePaths.push(framePath);
@@ -326,10 +409,11 @@ function buildFfmpegRenderArtifact(context) {
   const renderDir = path.join(stepArtifactsDir, "render");
   const previewManifestPath = path.join(stepArtifactsDir, "preview-manifest.json");
   const galleryPath = path.join(stepArtifactsDir, "preview-gallery.html");
-  const compositionDir = path.join(context.artifacts_dir ?? process.cwd(), context.run_id ?? "global", "compor-layout", "composition");
+  const compositionDir = resolveCompositionDir(context);
   const previewFiles = [];
-  const outputFormat = context.request_context?.output_format ?? "static-post";
-  const requestedFrames = Math.max(1, Number(context.request_context?.frame_count ?? (outputFormat === "carousel" ? 3 : 1)));
+  const outputFormat = resolveOutputFormat(context);
+  const requestedFrames = resolveFrameCount(outputFormat, context.request_context?.frame_count);
+  const playlistPath = path.join(stepArtifactsDir, "preview-playlist.json");
 
   ensureDirectory(renderDir);
 
@@ -340,15 +424,28 @@ function buildFfmpegRenderArtifact(context) {
     if (fs.existsSync(sourcePath)) {
       fs.copyFileSync(sourcePath, targetPath);
     } else {
-      const fallbackSvg = createSlideSvg({
-        title: (context.request_context?.brand_slug ?? "doze-crew").toUpperCase(),
-        subtitle: `${context.request_context?.campaign_slug ?? "creative-baseline"} • preview fallback`,
-        accent: context.request_context?.accent_color ?? "#ff4d4f",
-        slideIndex: index,
-        slideCount: requestedFrames,
-        width: 1080,
-        height: outputFormat === "stories" ? 1920 : 1350
-      });
+      const { width, height } = resolveCanvas(outputFormat);
+      const fallbackSvg =
+        outputFormat === "vertical-video"
+          ? createStoryboardSvg({
+              title: (context.request_context?.brand_slug ?? "doze-crew").toUpperCase(),
+              subtitle: `${context.request_context?.campaign_slug ?? "creative-baseline"} • preview fallback`,
+              accent: context.request_context?.accent_color ?? "#ff4d4f",
+              beatLabel: `Fallback beat ${index}`,
+              index,
+              count: requestedFrames,
+              width,
+              height
+            })
+          : createSlideSvg({
+              title: (context.request_context?.brand_slug ?? "doze-crew").toUpperCase(),
+              subtitle: `${context.request_context?.campaign_slug ?? "creative-baseline"} • preview fallback`,
+              accent: context.request_context?.accent_color ?? "#ff4d4f",
+              slideIndex: index,
+              slideCount: requestedFrames,
+              width,
+              height
+            });
       writeTextArtifact(targetPath, fallbackSvg);
     }
 
@@ -371,10 +468,20 @@ function buildFfmpegRenderArtifact(context) {
       index: index + 1,
       path: filePath
     })),
-    gallery_path: galleryPath
+    gallery_path: galleryPath,
+    playlist_path: playlistPath
   };
 
   writeJsonArtifact(previewManifestPath, manifest);
+  writeJsonArtifact(playlistPath, {
+    tool: "ffmpeg-render",
+    sequence_kind: outputFormat === "vertical-video" ? "vertical-preview-cut" : "image-preview-strip",
+    items: previewFiles.map((filePath, index) => ({
+      index: index + 1,
+      path: filePath,
+      duration_ms: outputFormat === "vertical-video" ? 850 : null
+    }))
+  });
 
   return {
     tool: "ffmpeg-render",
@@ -386,7 +493,8 @@ function buildFfmpegRenderArtifact(context) {
       output_format: outputFormat,
       preview_manifest_path: previewManifestPath,
       preview_files: previewFiles,
-      gallery_path: galleryPath
+      gallery_path: galleryPath,
+      playlist_path: playlistPath
     }
   };
 }

--- a/product/tests/e2e/README-RUNBOOK.md
+++ b/product/tests/e2e/README-RUNBOOK.md
@@ -11,9 +11,10 @@
 2. execute marketing scenario
 3. execute intelligence scenario
 4. execute creative image scenario and approve render gate
-5. approve and reject checkpoints
-6. promote and rollback capability
-7. restart services and verify recovery
+5. execute creative video scenario and approve preview gate
+6. approve and reject checkpoints
+7. promote and rollback capability
+8. restart services and verify recovery
 
 ## Verification points
 
@@ -23,6 +24,7 @@
 - audit trail
 - output availability
 - persisted preview files and manifest availability
+- persisted vertical playlist and storyboard availability
 
 ## Stop conditions
 

--- a/product/tests/e2e/README.md
+++ b/product/tests/e2e/README.md
@@ -14,6 +14,7 @@
 6. validar restart safety para runs aguardando checkpoint
 7. validar rollback de capability com trilha auditável
 8. validar o primeiro fluxo renderizável de `creative-image` com artifacts persistidos
+9. validar o primeiro fluxo vertical renderizável de `creative-video` com shot plan, edit plan e previews persistidos
 
 ## Scenario matrix
 
@@ -27,6 +28,7 @@
 | Rollback | desfazer uma promoção | status volta ao estado anterior com evento auditado | staging only |
 | Restart recovery | reiniciar API/worker | run retoma do último estado seguro | staging only |
 | Creative image render | renderizar a primeira peça estática/carrossel | `asset_plan`, `composition_plan`, `preview_manifest` e previews persistidos | staging only |
+| Creative video render | renderizar o primeiro corte vertical curto | `shot_plan`, `edit_decision_list`, `preview_manifest` e previews verticais persistidos | staging only |
 
 ## Acceptance criteria
 
@@ -35,6 +37,7 @@
 - checkpoints rejeitados precisam levar o run para o passo correto
 - os outputs precisam permanecer consultáveis após restart
 - o fluxo `creative-image` precisa persistir arquivos renderizáveis consultáveis no storage local
+- o fluxo `creative-video` precisa persistir storyboard, previews e playlist consultáveis no storage local
 - qualquer validação em produção continua proibida até o gate staging ficar verde
 - o comando `npm --prefix product run regression` executa a suíte completa sem passos manuais intermediários
 

--- a/product/tests/e2e/SCENARIO_MATRIX.md
+++ b/product/tests/e2e/SCENARIO_MATRIX.md
@@ -14,6 +14,7 @@
 | E2E-05 | Rollback approval | rollback pending | approve rollback | capability transitions back and audit is stored |
 | E2E-06 | Restart recovery | run waiting_checkpoint | restart services | run state restored without losing checkpoint |
 | E2E-07 | Creative image render | `creative-image` at least `staging` | start run, render previews, approve render gate | preview artifacts and manifest persistidos |
+| E2E-08 | Creative video render | `creative-video` at least `staging` | start run, render vertical previews, approve preview gate | shot plan, edit plan, playlist and previews persistidos |
 
 ## Notes
 
@@ -21,3 +22,4 @@
 - production validation is explicitly out of scope here
 - write-capable integrations require explicit approval path
 - `creative-image` is validated with dry-run artifacts only; no production publishing is involved
+- `creative-video` is validated with storyboard and vertical preview artifacts only; no production publishing is involved

--- a/product/tests/e2e/run.mjs
+++ b/product/tests/e2e/run.mjs
@@ -279,6 +279,10 @@ async function runCreativeScenario() {
     squads.items.some((item) => item.slug === "creative-image"),
     "Creative image squad should be listed by the API"
   );
+  assert(
+    squads.items.some((item) => item.slug === "creative-video"),
+    "Creative video squad should be listed by the API"
+  );
 
   const referenceRun = await requestJson("/v1/runs", {
     method: "POST",
@@ -405,17 +409,83 @@ async function runCreativeScenario() {
   );
   assert(existsSync(previewArtifact.details.gallery_path), "Preview gallery file should exist");
 
+  const videoRun = await requestJson("/v1/runs", {
+    method: "POST",
+    body: JSON.stringify({
+      squad_slug: "creative-video",
+      workspace_slug: "doze",
+      requested_by: "e2e",
+      intent_kind: "creative-video",
+      machine_profile: "balanced",
+      environment_scope: "staging",
+      request_context: {
+        brand_slug: "doze-crew",
+        campaign_slug: "opium-drop",
+        channel: "instagram-reels",
+        style_direction: "opium-industrial",
+        output_format: "vertical-video",
+        frame_count: 6,
+        accent_color: "#ff4d4f"
+      }
+    })
+  });
+
+  const completedVideo = await driveCheckpointedRun(videoRun.id, { expectedCheckpoints: 1 });
+  assert(completedVideo.status === "succeeded", "Creative video run did not finish successfully");
+
+  const videoOutputs = await requestJson(`/v1/runs/${videoRun.id}/outputs`);
+  assert(
+    videoOutputs.items.some((item) => item.artifact_type === "shot_plan"),
+    "Creative video should produce a shot plan"
+  );
+  assert(
+    videoOutputs.items.some((item) => item.artifact_type === "vfx_plan"),
+    "Creative video should produce a vfx plan"
+  );
+  assert(
+    videoOutputs.items.some((item) => item.artifact_type === "edit_decision_list"),
+    "Creative video should produce an edit decision list"
+  );
+  assert(
+    videoOutputs.items.some((item) => item.artifact_type === "composition_plan"),
+    "Creative video should produce a composition plan"
+  );
+  assert(
+    videoOutputs.items.some((item) => item.artifact_type === "preview_manifest"),
+    "Creative video should produce a preview manifest"
+  );
+
+  const videoArtifacts = await requestJson(`/v1/runs/${videoRun.id}/artifacts`);
+  const videoCompositionArtifact = videoArtifacts.items.find((item) => item.artifact_type === "composition_plan");
+  const videoPreviewArtifact = videoArtifacts.items.find((item) => item.artifact_type === "preview_manifest");
+
+  assert(videoCompositionArtifact, "Creative video should persist a composition artifact");
+  assert(videoPreviewArtifact, "Creative video should persist a preview artifact");
+  assert(existsSync(videoCompositionArtifact.details.composition_path), "Video composition plan file should exist");
+  assert(
+    videoCompositionArtifact.details.frame_paths.every((framePath) => existsSync(framePath)),
+    "Video storyboard frames should exist"
+  );
+  assert(existsSync(videoPreviewArtifact.details.preview_manifest_path), "Video preview manifest file should exist");
+  assert(
+    videoPreviewArtifact.details.preview_files.every((previewPath) => existsSync(previewPath)),
+    "Video preview files should exist"
+  );
+  assert(existsSync(videoPreviewArtifact.details.gallery_path), "Video preview gallery file should exist");
+  assert(existsSync(videoPreviewArtifact.details.playlist_path), "Video preview playlist file should exist");
+
   const qaRun = await requestJson("/v1/runs", {
     method: "POST",
     body: JSON.stringify({
       squad_slug: "creative-qa",
       workspace_slug: "doze",
       requested_by: "e2e",
-      intent_kind: "creative-image",
+      intent_kind: "creative-video",
       machine_profile: "cpu-safe",
       environment_scope: "staging",
       request_context: {
-        channel: "instagram"
+        channel: "instagram-reels",
+        output_format: "vertical-video"
       }
     })
   });
@@ -437,6 +507,7 @@ async function runCreativeScenario() {
     referenceRunId: referenceRun.id,
     controlRunId: controlRun.id,
     imageRunId: imageRun.id,
+    videoRunId: videoRun.id,
     qaRunId: qaRun.id
   };
 }

--- a/workboard/BACKLOG.md
+++ b/workboard/BACKLOG.md
@@ -14,17 +14,17 @@
 
 ### P1 — Alta Prioridade
 
-### TASK-041 | Implementar `creative-video` como primeiro fluxo vertical renderizável
+### TASK-042 | Implementar `publishing-control` como empacotamento dry-run do fluxo criativo
 - **Tipo:** research
 - **Prioridade:** P1
-- **Tamanho:** L
+- **Tamanho:** M
 - **Status:** `backlog`
-- **Objetivo:** estender a trilha criativa para o primeiro fluxo vertical curto com planejamento de frames, composição, render de previews e QA orientado a identidade e retenção.
-- **Dependências:** TASK-040 concluída
+- **Objetivo:** conectar `creative-image` e `creative-video` a um fluxo de empacotamento dry-run com receipts persistidos, sem publicação real por default.
+- **Dependências:** TASK-041 concluída
 - **Output esperado:**
-  - fluxo `creative-video` implementado no `product/`
-  - artifacts persistidos de shot plan, edit plan e previews verticais
-  - regressão cobrindo o fluxo de vídeo curto
-  - documentação local/staging do primeiro fluxo vertical renderizável
+  - fluxo `publishing-control` implementado no `product/`
+  - artifacts persistidos de `publication_plan` e `publish_receipt`
+  - regressão cobrindo o handoff criativo para publicação dry-run
+  - documentação local/staging do empacotamento de entrega
 
 ## Backlog do Squad 1 (a ser preenchido pelo Squad 0 via TASK-015)

--- a/workboard/DONE.md
+++ b/workboard/DONE.md
@@ -21,6 +21,28 @@
 
 ## Histórico
 
+### TASK-041 | Implementar `creative-video` como primeiro fluxo vertical renderizável
+- **Concluída em:** 2026-04-24
+- **Por:** codex
+- **Issue:** #26 (fechada)
+- **Branch:** task/26-creative-video-first-renderable
+- **Output produzido:**
+  - `product/packages/shared/src/seeds.js`
+  - `product/packages/skills/src/catalog.js`
+  - `product/packages/runtime/src/service.js`
+  - `product/packages/tools/src/runner.js`
+  - `product/tests/e2e/run.mjs`
+  - `product/README.md`
+  - `product/tests/e2e/README.md`
+  - `product/tests/e2e/SCENARIO_MATRIX.md`
+  - `product/tests/e2e/README-RUNBOOK.md`
+  - `workboard/BACKLOG.md`
+  - `workboard/IN_PROGRESS.md`
+  - `workboard/DONE.md`
+  - `handoffs/ACTIVE.md`
+  - `handoffs/snapshots/2026-04-24-codex-task-041-complete.md`
+- **Notas:** O produto agora executa `creative-video` como primeiro fluxo vertical renderizável, persistindo `shot_plan`, `vfx_plan`, `edit_decision_list`, storyboard vertical, previews SVG e playlist de dry-run validados pela regressão canônica.
+
 ### TASK-040 | Implementar `creative-image` como primeiro fluxo criativo renderizável
 - **Concluída em:** 2026-04-24
 - **Por:** codex


### PR DESCRIPTION
## Summary
- adiciona o squad `creative-video` como primeiro fluxo vertical renderizável
- persiste `shot_plan`, `vfx_plan`, `edit_decision_list`, storyboard vertical e playlist de dry-run
- expande a regressão e a documentação local/staging para o novo corte de vídeo

## Testing
- npm --prefix product run check
- npm --prefix product run regression

Closes #26