### PR TITLE
TASK-042: implementar publishing-control como empacotamento dry-run

### DIFF
--- a/handoffs/ACTIVE.md
+++ b/handoffs/ACTIVE.md
@@ -8,7 +8,7 @@
 ## Estado do Bastão
 
 - **baton:** UNASSIGNED
-- **last-updated-by:** codex (task 041 completed)
+- **last-updated-by:** codex (task 042 completed)
 - **last-updated-at:** 2026-04-24
 - **last-read-by:** codex
 - **last-read-at:** 2026-04-24
@@ -17,35 +17,34 @@
 
 ## Tasks em Voo
 
-1. TASK-041 concluída com o primeiro fluxo vertical renderizável em `product/`.
-2. Próximo passo: iniciar `TASK-042` no backlog.
+1. TASK-042 concluída com o primeiro handoff de publicação dry-run em `product/`.
+2. Próximo passo: iniciar `TASK-043` no backlog.
 
 ---
 
 ## Última Ação Completada
 
-Fechamento da TASK-041 com `creative-video` implementado e regressão verde.
+Fechamento da TASK-042 com `publishing-control` implementado e regressão verde.
 
 **Mudanças concluídas nesta sessão:**
-- `product/packages/shared/src/seeds.js` atualizado com o squad `creative-video` e capabilities de video
-- `product/packages/skills/src/catalog.js` atualizado com `frame-planner`, `motion-editor` e `vfx-finisher`
-- `product/packages/tools/src/runner.js` atualizado para persistir storyboard vertical, previews SVG e playlist de dry-run
-- `product/packages/runtime/src/service.js` atualizado com summaries dos contracts de video
-- `product/tests/e2e/run.mjs` atualizado para cobrir o fluxo renderizável de video
+- `product/packages/shared/src/seeds.js` atualizado com o squad `publishing-control`
+- `product/packages/tools/src/runner.js` atualizado para persistir bundle e recibo de `publish-dry-run`
+- `product/packages/runtime/src/service.js` atualizado com summaries de contratos de publicacao
+- `product/tests/e2e/run.mjs` atualizado para cobrir o handoff criativo para `publishing-control`
 - `product/README.md` e docs de `product/tests/e2e/` atualizados para refletir o novo corte
 - `npm --prefix product run check` executado com sucesso
 - `npm --prefix product run regression` executado com sucesso
-- `workboard/BACKLOG.md` atualizado com `TASK-042`
+- `workboard/BACKLOG.md` atualizado com `TASK-043`
 - `workboard/IN_PROGRESS.md` zerado
-- `workboard/DONE.md` atualizado para incluir `TASK-041`
+- `workboard/DONE.md` atualizado para incluir `TASK-042`
 - `handoffs/ACTIVE.md` reconciliado para refletir o fechamento da task
 
 ---
 
 ## Próxima Ação Recomendada
 
-1. Iniciar `TASK-042`
-2. Implementar `publishing-control` como empacotamento dry-run do fluxo criativo
+1. Iniciar `TASK-043`
+2. Implementar adapters de publicação por canal em staging-first
 3. Manter staging-first antes de qualquer passo ligado ao servidor de produção
 
 **Papéis recomendados para a próxima sessão:** `Program Architect`, `Workflow Field Researcher`
@@ -60,7 +59,7 @@ NENHUM.
 
 ## Snapshot de Contexto
 
-`handoffs/snapshots/2026-04-24-codex-task-041-complete.md`
+`handoffs/snapshots/2026-04-24-codex-task-042-complete.md`
 
 ---
 
@@ -74,8 +73,8 @@ O repositório agora tem duas camadas ativas e coerentes:
 - o registry agora tem lifecycle formal e approvals explícitos
 
 **O que fazer a seguir:**
-- iniciar `TASK-042`
-- conectar `creative-image` e `creative-video` ao primeiro handoff de publicação dry-run
+- iniciar `TASK-043`
+- expandir `publishing-control` para adapters por canal ainda em staging-first
 - seguir preservando o fluxo operacional atual da Doze e o guardrail de staging-first
 
 **Próximo agente recomendado:** `Program Architect` com apoio de `Workflow Field Researcher`

--- a/handoffs/snapshots/2026-04-24-codex-task-042-complete.md
+++ b/handoffs/snapshots/2026-04-24-codex-task-042-complete.md
@@ -1,0 +1,27 @@
+# Snapshot — TASK-042
+
+**Data:** 2026-04-24  
+**Agente:** codex  
+**Branch:** `task/28-publishing-control-dry-run`  
+**Issue:** `#28`
+
+## Objetivo
+
+Implementar `publishing-control` como o primeiro handoff de empacotamento dry-run do fluxo criativo, sem publicação real por default.
+
+## Entregas
+
+- seed de `publishing-control` adicionado ao produto
+- `publish-dry-run` agora persiste `publication-plan.json` e `publish-receipt.json`
+- o empacotamento coleta assets de runs criativos anteriores por `asset_run_ids`
+- a regressão cobre `publishing-control` com checkpoint, bundle persistido e recibo verificável
+- a documentação de produto e E2E foi alinhada com o novo corte
+
+## Validação
+
+- `npm --prefix product run check`
+- `npm --prefix product run regression`
+
+## Próxima ação recomendada
+
+Iniciar `TASK-043` para expandir `publishing-control` com adapters de publicação por canal em staging-first, ainda sem escrita externa por default.

--- a/product/README.md
+++ b/product/README.md
@@ -64,12 +64,14 @@ O baseline do produto agora também inclui o primeiro corte da trilha criativa:
 - `creative-qa`
 - `creative-image`
 - `creative-video`
+- `publishing-control`
 
 Neste corte:
 - os squads já existem como seeds do produto
-- o fluxo `contexto -> referencia -> composicao/render -> QA` já pode ser iniciado localmente para imagem e video curto
+- o fluxo `contexto -> referencia -> composicao/render -> QA -> publishing dry-run` já pode ser iniciado localmente para imagem e video curto
 - `creative-image` persiste plano de assets, composicao declarativa, previews renderizaveis em SVG e gallery HTML de dry-run
 - `creative-video` persiste `shot_plan`, `vfx_plan`, `edit_decision_list`, storyboard vertical, previews SVG e playlist de dry-run
+- `publishing-control` persiste `publication_plan`, `publish_receipt` e empacota assets anteriores sem publicar em producao
 - o objetivo ainda é `local-dev` e `staging`
 - produção continua fora do caminho default
 
@@ -78,3 +80,4 @@ O que ainda nao entra neste corte:
 - publicação real por default
 - render final dependente de stack externa além do dry-run local/staging
 - integrações multimodais pesadas fora do perfil local/staging
+- qualquer escrita externa além do empacotamento local de dry-run

--- a/product/packages/runtime/src/service.js
+++ b/product/packages/runtime/src/service.js
@@ -441,6 +441,8 @@ export class RuntimeService {
       "shot_plan.json": "Plano de shots consolidado",
       "edit_decision_list.json": "Edit decision list consolidado",
       "vfx_plan.json": "Plano de VFX consolidado",
+      "publication_plan.json": "Plano de publicacao consolidado",
+      "publish_receipt.json": "Recibo de publicacao dry-run consolidado",
       "creative_intent.json": "Intento criativo consolidado",
       "approval_packet.json": "Pacote de aprovacao preparado",
       "brand_context.json": "Contexto de marca consolidado",

--- a/product/packages/shared/src/seeds.js
+++ b/product/packages/shared/src/seeds.js
@@ -331,6 +331,47 @@ function createCreativeVideoSteps() {
   ];
 }
 
+function createPublishingControlSteps() {
+  return [
+    {
+      id: "planejar-publicacao",
+      kind: "prompt",
+      executor: "inline",
+      label: "Consolida o plano de publicacao e handoff de entrega",
+      output_contracts: ["publication_plan.json"],
+      machine_profile: "cpu-safe",
+      environment_scope: "staging",
+      qa_gate: "delivery",
+      risk_level: "medium"
+    },
+    {
+      id: "empacotar-dry-run",
+      kind: "tool",
+      executor: "tool-runner",
+      label: "Empacota os assets aprovados em modo dry-run",
+      tool_slugs: ["publish-dry-run"],
+      input_contracts: ["publication_plan.json"],
+      machine_profile: "cpu-safe",
+      environment_scope: "staging",
+      qa_gate: "delivery",
+      risk_level: "medium"
+    },
+    {
+      id: "aprovar-handoff",
+      kind: "checkpoint",
+      executor: "checkpoint",
+      label: "Aprovar handoff de publicacao em dry-run",
+      input_contracts: ["publish_receipt.json"],
+      requiresCheckpoint: true,
+      on_reject: "planejar-publicacao",
+      machine_profile: "cpu-safe",
+      environment_scope: "staging",
+      qa_gate: "brand-and-delivery",
+      risk_level: "high"
+    }
+  ];
+}
+
 export function createSeeds() {
   const capabilities = [
     {
@@ -654,6 +695,7 @@ export function createSeeds() {
   const creativeQaId = createId();
   const creativeImageId = createId();
   const creativeVideoId = createId();
+  const publishingControlId = createId();
 
   const squads = [
     {
@@ -796,6 +838,27 @@ export function createSeeds() {
         .filter((capability) => ["brand-qa", "delivery-qa"].includes(capability.slug))
         .map((capability) => capability.id),
       steps: createCreativeVideoSteps()
+    },
+    {
+      id: publishingControlId,
+      slug: "publishing-control",
+      name: "Publishing Control",
+      workspace_slug: "doze",
+      version: "1.0.0",
+      pipeline_id: createId(),
+      capability_ids: capabilities
+        .filter((capability) => ["publish-dry-run", "brand-qa", "delivery-qa"].includes(capability.slug))
+        .map((capability) => capability.id),
+      memory_scope: "run",
+      default_model_tier: "fast",
+      system_family: "publishing",
+      machine_profile: "cpu-safe",
+      environment_scope: "staging",
+      context_precedence: ["operational-truth", "campaign-context", "brand-profile", "creative-playbook"],
+      qa_capability_ids: capabilities
+        .filter((capability) => ["brand-qa", "delivery-qa"].includes(capability.slug))
+        .map((capability) => capability.id),
+      steps: createPublishingControlSteps()
     }
   ];
 

--- a/product/packages/tools/src/runner.js
+++ b/product/packages/tools/src/runner.js
@@ -151,6 +151,44 @@ function resolveCompositionDir(context) {
   return candidates.find((candidate) => fs.existsSync(candidate)) ?? candidates[0];
 }
 
+function collectPublishableArtifacts(context) {
+  const artifactRoot = path.join(context.artifacts_dir ?? process.cwd(), context.run_id ?? "global");
+  const requestedRunIds = context.request_context?.asset_run_ids ?? [];
+  const previewCandidates = [];
+
+  for (const referencedRunId of requestedRunIds) {
+    const renderDirs = [
+      path.join(context.artifacts_dir ?? process.cwd(), referencedRunId, "renderizar-previews", "render"),
+      path.join(context.artifacts_dir ?? process.cwd(), referencedRunId, "renderizar-video", "render")
+    ];
+
+    for (const renderDir of renderDirs) {
+      if (!fs.existsSync(renderDir)) {
+        continue;
+      }
+
+      const files = fs
+        .readdirSync(renderDir)
+        .filter((entry) => entry.endsWith(".svg"))
+        .map((entry) => path.join(renderDir, entry));
+
+      previewCandidates.push(...files);
+    }
+  }
+
+  if (previewCandidates.length > 0) {
+    return previewCandidates;
+  }
+
+  const fallbackFiles = fs.existsSync(artifactRoot)
+    ? fs.readdirSync(artifactRoot, { recursive: true })
+        .filter((entry) => typeof entry === "string" && entry.endsWith(".svg"))
+        .map((entry) => path.join(artifactRoot, entry))
+    : [];
+
+  return fallbackFiles;
+}
+
 function buildGa4Artifact(context) {
   return {
     tool: "ga4",
@@ -500,6 +538,36 @@ function buildFfmpegRenderArtifact(context) {
 }
 
 function buildPublishDryRunArtifact(context) {
+  const stepArtifactsDir = getStepArtifactsDir(context);
+  const publishBundlePath = path.join(stepArtifactsDir, "publication-plan.json");
+  const publishReceiptPath = path.join(stepArtifactsDir, "publish-receipt.json");
+  const previewFiles = collectPublishableArtifacts(context);
+  const destination = context.request_context?.channel ?? "instagram";
+  const bundle = {
+    tool: "publish-dry-run",
+    destination,
+    mode: "dry-run",
+    assets: previewFiles.map((filePath, index) => ({
+      index: index + 1,
+      path: filePath
+    })),
+    requested_asset_run_ids: context.request_context?.asset_run_ids ?? []
+  };
+
+  const receipt = {
+    tool: "publish-dry-run",
+    mode: "dry-run",
+    destination,
+    status: "packaged",
+    packaged_assets: previewFiles.length,
+    requested_at: new Date().toISOString(),
+    source_run_id: context.run_id,
+    publication_plan_path: publishBundlePath
+  };
+
+  writeJsonArtifact(publishBundlePath, bundle);
+  writeJsonArtifact(publishReceiptPath, receipt);
+
   return {
     tool: "publish-dry-run",
     artifact_type: "publish_receipt",
@@ -507,7 +575,11 @@ function buildPublishDryRunArtifact(context) {
     details: {
       workspace: context.workspace_slug,
       mode: "dry-run",
-      destination: context.request_context?.channel ?? "instagram"
+      destination,
+      publication_plan_path: publishBundlePath,
+      publish_receipt_path: publishReceiptPath,
+      packaged_assets: previewFiles.length,
+      asset_run_ids: context.request_context?.asset_run_ids ?? []
     }
   };
 }

--- a/product/tests/e2e/README-RUNBOOK.md
+++ b/product/tests/e2e/README-RUNBOOK.md
@@ -12,9 +12,10 @@
 3. execute intelligence scenario
 4. execute creative image scenario and approve render gate
 5. execute creative video scenario and approve preview gate
-6. approve and reject checkpoints
-7. promote and rollback capability
-8. restart services and verify recovery
+6. execute publishing dry-run scenario and approve handoff gate
+7. approve and reject checkpoints
+8. promote and rollback capability
+9. restart services and verify recovery
 
 ## Verification points
 
@@ -25,6 +26,7 @@
 - output availability
 - persisted preview files and manifest availability
 - persisted vertical playlist and storyboard availability
+- persisted publication bundle and receipt availability
 
 ## Stop conditions
 

--- a/product/tests/e2e/README.md
+++ b/product/tests/e2e/README.md
@@ -15,6 +15,7 @@
 7. validar rollback de capability com trilha auditável
 8. validar o primeiro fluxo renderizável de `creative-image` com artifacts persistidos
 9. validar o primeiro fluxo vertical renderizável de `creative-video` com shot plan, edit plan e previews persistidos
+10. validar o handoff criativo para `publishing-control` com `publication_plan` e `publish_receipt` persistidos
 
 ## Scenario matrix
 
@@ -29,6 +30,7 @@
 | Restart recovery | reiniciar API/worker | run retoma do último estado seguro | staging only |
 | Creative image render | renderizar a primeira peça estática/carrossel | `asset_plan`, `composition_plan`, `preview_manifest` e previews persistidos | staging only |
 | Creative video render | renderizar o primeiro corte vertical curto | `shot_plan`, `edit_decision_list`, `preview_manifest` e previews verticais persistidos | staging only |
+| Publishing dry-run | empacotar criativos aprovados | `publication_plan`, `publish_receipt` e bundle persistidos | staging only |
 
 ## Acceptance criteria
 
@@ -38,6 +40,7 @@
 - os outputs precisam permanecer consultáveis após restart
 - o fluxo `creative-image` precisa persistir arquivos renderizáveis consultáveis no storage local
 - o fluxo `creative-video` precisa persistir storyboard, previews e playlist consultáveis no storage local
+- o fluxo `publishing-control` precisa persistir bundle e recibo de dry-run sem publicar em sistema externo
 - qualquer validação em produção continua proibida até o gate staging ficar verde
 - o comando `npm --prefix product run regression` executa a suíte completa sem passos manuais intermediários
 

--- a/product/tests/e2e/SCENARIO_MATRIX.md
+++ b/product/tests/e2e/SCENARIO_MATRIX.md
@@ -15,6 +15,7 @@
 | E2E-06 | Restart recovery | run waiting_checkpoint | restart services | run state restored without losing checkpoint |
 | E2E-07 | Creative image render | `creative-image` at least `staging` | start run, render previews, approve render gate | preview artifacts and manifest persistidos |
 | E2E-08 | Creative video render | `creative-video` at least `staging` | start run, render vertical previews, approve preview gate | shot plan, edit plan, playlist and previews persistidos |
+| E2E-09 | Publishing dry-run handoff | `publishing-control` at least `staging` | start run with creative asset run ids, approve handoff gate | publication plan, receipt and bundle persistidos |
 
 ## Notes
 
@@ -23,3 +24,4 @@
 - write-capable integrations require explicit approval path
 - `creative-image` is validated with dry-run artifacts only; no production publishing is involved
 - `creative-video` is validated with storyboard and vertical preview artifacts only; no production publishing is involved
+- `publishing-control` is validated only as local/staging packaging; no publication API is called

--- a/product/tests/e2e/run.mjs
+++ b/product/tests/e2e/run.mjs
@@ -283,6 +283,10 @@ async function runCreativeScenario() {
     squads.items.some((item) => item.slug === "creative-video"),
     "Creative video squad should be listed by the API"
   );
+  assert(
+    squads.items.some((item) => item.slug === "publishing-control"),
+    "Publishing control squad should be listed by the API"
+  );
 
   const referenceRun = await requestJson("/v1/runs", {
     method: "POST",
@@ -503,12 +507,60 @@ async function runCreativeScenario() {
     "Creative QA should produce delivery QA output"
   );
 
+  const publishingRun = await requestJson("/v1/runs", {
+    method: "POST",
+    body: JSON.stringify({
+      squad_slug: "publishing-control",
+      workspace_slug: "doze",
+      requested_by: "e2e",
+      intent_kind: "creative-publishing",
+      machine_profile: "cpu-safe",
+      environment_scope: "staging",
+      request_context: {
+        channel: "instagram-reels",
+        asset_run_ids: [imageRun.id, videoRun.id],
+        campaign_slug: "opium-drop"
+      }
+    })
+  });
+
+  const completedPublishing = await driveCheckpointedRun(publishingRun.id, { expectedCheckpoints: 1 });
+  assert(completedPublishing.status === "succeeded", "Publishing control run did not finish successfully");
+
+  const publishingOutputs = await requestJson(`/v1/runs/${publishingRun.id}/outputs`);
+  assert(
+    publishingOutputs.items.some((item) => item.artifact_type === "publication_plan"),
+    "Publishing control should produce a publication plan"
+  );
+  assert(
+    publishingOutputs.items.some((item) => item.artifact_type === "publish_receipt"),
+    "Publishing control should produce a publish receipt"
+  );
+
+  const publishingArtifacts = await requestJson(`/v1/runs/${publishingRun.id}/artifacts`);
+  const publishReceiptArtifact = publishingArtifacts.items.find((item) => item.artifact_type === "publish_receipt");
+
+  assert(publishReceiptArtifact, "Publishing control should persist a publish receipt artifact");
+  assert(
+    existsSync(publishReceiptArtifact.details.publication_plan_path),
+    "Publication plan bundle file should exist"
+  );
+  assert(
+    existsSync(publishReceiptArtifact.details.publish_receipt_path),
+    "Publish receipt file should exist"
+  );
+  assert(
+    publishReceiptArtifact.details.packaged_assets >= 2,
+    "Publishing control should package assets from previous creative runs"
+  );
+
   return {
     referenceRunId: referenceRun.id,
     controlRunId: controlRun.id,
     imageRunId: imageRun.id,
     videoRunId: videoRun.id,
-    qaRunId: qaRun.id
+    qaRunId: qaRun.id,
+    publishingRunId: publishingRun.id
   };
 }
 

--- a/workboard/BACKLOG.md
+++ b/workboard/BACKLOG.md
@@ -14,17 +14,17 @@
 
 ### P1 — Alta Prioridade
 
-### TASK-042 | Implementar `publishing-control` como empacotamento dry-run do fluxo criativo
+### TASK-043 | Implementar adapters de publicação por canal em staging-first
 - **Tipo:** research
 - **Prioridade:** P1
-- **Tamanho:** M
+- **Tamanho:** L
 - **Status:** `backlog`
-- **Objetivo:** conectar `creative-image` e `creative-video` a um fluxo de empacotamento dry-run com receipts persistidos, sem publicação real por default.
-- **Dependências:** TASK-041 concluída
+- **Objetivo:** expandir o handoff de `publishing-control` para adapters por canal em staging-first, ainda sem escrita externa por default.
+- **Dependências:** TASK-042 concluída
 - **Output esperado:**
-  - fluxo `publishing-control` implementado no `product/`
-  - artifacts persistidos de `publication_plan` e `publish_receipt`
-  - regressão cobrindo o handoff criativo para publicação dry-run
-  - documentação local/staging do empacotamento de entrega
+  - adapters de destino versionados para canais prioritários
+  - receipts mais detalhados por canal em modo staging/dry-run
+  - regressão cobrindo roteamento de destino sem publicação real
+  - documentação de guardrails por canal
 
 ## Backlog do Squad 1 (a ser preenchido pelo Squad 0 via TASK-015)

--- a/workboard/DONE.md
+++ b/workboard/DONE.md
@@ -21,6 +21,27 @@
 
 ## Histórico
 
+### TASK-042 | Implementar `publishing-control` como empacotamento dry-run do fluxo criativo
+- **Concluída em:** 2026-04-24
+- **Por:** codex
+- **Issue:** #28 (fechada)
+- **Branch:** task/28-publishing-control-dry-run
+- **Output produzido:**
+  - `product/packages/shared/src/seeds.js`
+  - `product/packages/runtime/src/service.js`
+  - `product/packages/tools/src/runner.js`
+  - `product/tests/e2e/run.mjs`
+  - `product/README.md`
+  - `product/tests/e2e/README.md`
+  - `product/tests/e2e/SCENARIO_MATRIX.md`
+  - `product/tests/e2e/README-RUNBOOK.md`
+  - `workboard/BACKLOG.md`
+  - `workboard/IN_PROGRESS.md`
+  - `workboard/DONE.md`
+  - `handoffs/ACTIVE.md`
+  - `handoffs/snapshots/2026-04-24-codex-task-042-complete.md`
+- **Notas:** O produto agora executa `publishing-control` como handoff criativo de staging/dry-run, persistindo `publication_plan`, `publish_receipt` e bundle local sem chamar APIs externas.
+
 ### TASK-041 | Implementar `creative-video` como primeiro fluxo vertical renderizável
 - **Concluída em:** 2026-04-24
 - **Por:** codex


### PR DESCRIPTION
## Summary
- adiciona o squad `publishing-control` como handoff criativo de staging/dry-run
- persiste `publication_plan`, `publish_receipt` e bundle local sem chamar APIs externas
- expande a regressão e a documentação local/staging para o fluxo de empacotamento

## Testing
- npm --prefix product run check
- npm --prefix product run regression

Closes #28